### PR TITLE
Consolidate MM_PER_INCH into shared constants module

### DIFF
--- a/src/programmatic_drafting/analysis/vessel_drafter_metrics.py
+++ b/src/programmatic_drafting/analysis/vessel_drafter_metrics.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from programmatic_drafting.constants import MM_PER_INCH
 from programmatic_drafting.models.vessel_drafter import (
     DEFAULT_VESSEL_DRAFTER_LAYOUT,
-    MM_PER_INCH,
     VesselDrafterLayout,
 )
 from programmatic_drafting.projects.vessel_drafter_layout import (

--- a/src/programmatic_drafting/constants.py
+++ b/src/programmatic_drafting/constants.py
@@ -1,0 +1,5 @@
+"""Shared drafting constants."""
+
+from __future__ import annotations
+
+MM_PER_INCH: float = 25.4

--- a/src/programmatic_drafting/models/cylindrical_bath.py
+++ b/src/programmatic_drafting/models/cylindrical_bath.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from math import cos, radians, sin
 from typing import Any
 
-MM_PER_INCH = 25.4
+from programmatic_drafting.constants import MM_PER_INCH
 
 
 @dataclass(frozen=True)

--- a/src/programmatic_drafting/models/vessel_drafter.py
+++ b/src/programmatic_drafting/models/vessel_drafter.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from math import radians
 from typing import Any
 
+from programmatic_drafting.constants import MM_PER_INCH
 from programmatic_drafting.contracts import (
     require_fraction,
     require_integer_at_least,
@@ -17,8 +18,6 @@ from programmatic_drafting.models.vessel_materials import (
     DEFAULT_VESSEL_MATERIALS_BY_NAME,
     MaterialProperties,
 )
-
-MM_PER_INCH = 25.4
 
 
 @dataclass(frozen=True)

--- a/src/programmatic_drafting/preview/vessel_drafter_scene.py
+++ b/src/programmatic_drafting/preview/vessel_drafter_scene.py
@@ -9,9 +9,9 @@ from typing import TypeAlias, cast
 
 import numpy as np
 
+from programmatic_drafting.constants import MM_PER_INCH
 from programmatic_drafting.models.vessel_drafter import (
     DEFAULT_VESSEL_DRAFTER_LAYOUT,
-    MM_PER_INCH,
     VesselDrafterLayout,
 )
 from programmatic_drafting.preview.vessel_drafter_view_options import (

--- a/src/programmatic_drafting/projects/vessel_drafter_layout.py
+++ b/src/programmatic_drafting/projects/vessel_drafter_layout.py
@@ -19,9 +19,9 @@ from build123d import (
     revolve,
 )
 
+from programmatic_drafting.constants import MM_PER_INCH
 from programmatic_drafting.models.vessel_drafter import (
     DEFAULT_VESSEL_DRAFTER_LAYOUT,
-    MM_PER_INCH,
     VesselDrafterLayout,
     VesselElectrodePlacement,
     VesselLidPort,

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from programmatic_drafting.constants import MM_PER_INCH
+
+
+def test_mm_per_inch_is_shared_across_drafting_models() -> None:
+    root = Path(__file__).resolve().parents[1]
+    bath_source = (
+        root / "src/programmatic_drafting/models/cylindrical_bath.py"
+    ).read_text()
+    vessel_source = (
+        root / "src/programmatic_drafting/models/vessel_drafter.py"
+    ).read_text()
+
+    assert MM_PER_INCH == 25.4
+    assert "MM_PER_INCH = 25.4" not in bath_source
+    assert "MM_PER_INCH = 25.4" not in vessel_source
+    assert "from programmatic_drafting.constants import MM_PER_INCH" in bath_source
+    assert "from programmatic_drafting.constants import MM_PER_INCH" in vessel_source


### PR DESCRIPTION
Closes #23.

This moves `MM_PER_INCH` into `programmatic_drafting.constants` and updates the vessel drafter, cylindrical bath, and downstream geometry/metrics modules to import the shared value.

Validation:
- `PYTHONPATH=src python3 -m pytest tests/test_constants.py tests/test_vessel_drafter_defaults.py`
- `python3 -m ruff check src/programmatic_drafting/constants.py src/programmatic_drafting/models/cylindrical_bath.py src/programmatic_drafting/models/vessel_drafter.py src/programmatic_drafting/projects/vessel_drafter_layout.py src/programmatic_drafting/analysis/vessel_drafter_metrics.py src/programmatic_drafting/preview/vessel_drafter_scene.py tests/test_constants.py`

A broader pytest slice was attempted, but this environment is missing `build123d`.