### PR TITLE
Replace CLI prints with logging

### DIFF
--- a/src/programmatic_drafting/cli.py
+++ b/src/programmatic_drafting/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 from pathlib import Path
 
 from programmatic_drafting.exporters.step_export import (
@@ -10,6 +11,8 @@ from programmatic_drafting.exporters.step_export import (
     export_default_layout_step,
     export_vessel_drafter_default_step,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -77,7 +80,7 @@ def main() -> int:
             output_path=Path(args.output),
             manifest_path=Path(args.manifest),
         )
-        print(step_path)
+        logger.info("Exported electrode advisor STEP artifact to %s", step_path)
         return 0
 
     if args.command == "export-cylindrical-bath-layout":
@@ -85,7 +88,7 @@ def main() -> int:
             output_path=Path(args.output),
             manifest_path=Path(args.manifest),
         )
-        print(step_path)
+        logger.info("Exported cylindrical bath STEP artifact to %s", step_path)
         return 0
 
     if args.command == "export-vessel-drafter-default":
@@ -93,7 +96,7 @@ def main() -> int:
             output_path=Path(args.output),
             manifest_path=Path(args.manifest),
         )
-        print(step_path)
+        logger.info("Exported vessel drafter STEP artifact to %s", step_path)
         return 0
 
     if args.command == "launch-vessel-drafter-gui":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+import sys
+
+import pytest
+
+from programmatic_drafting import cli
+
+
+@pytest.mark.parametrize(
+    ("command", "export_name", "expected_message"),
+    [
+        (
+            "export-electrode-advisor-default",
+            "export_default_layout_step",
+            "Exported electrode advisor STEP artifact to /tmp/electrode.step",
+        ),
+        (
+            "export-cylindrical-bath-layout",
+            "export_cylindrical_bath_layout_step",
+            "Exported cylindrical bath STEP artifact to /tmp/cylindrical.step",
+        ),
+        (
+            "export-vessel-drafter-default",
+            "export_vessel_drafter_default_step",
+            "Exported vessel drafter STEP artifact to /tmp/vessel.step",
+        ),
+    ],
+)
+def test_main_logs_exported_step_path(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    command: str,
+    export_name: str,
+    expected_message: str,
+) -> None:
+    def fake_export(output_path, manifest_path):
+        return f"/tmp/{output_path.stem.split('_')[0]}.step"
+
+    monkeypatch.setattr(
+        cli,
+        export_name,
+        fake_export,
+    )
+    monkeypatch.setattr(sys, "argv", ["programmatic-drafting", command])
+
+    caplog.set_level(logging.INFO, logger="programmatic_drafting.cli")
+
+    assert cli.main() == 0
+    assert expected_message in caplog.text


### PR DESCRIPTION
This replaces the remaining `print()` calls under `src/` with module logging and adds a focused CLI regression test.

Validation:
- `pytest tests/test_cli.py`
- `ruff check src/programmatic_drafting/cli.py tests/test_cli.py`
- `rg -n "print\(" src/ -S

Closes #28