### PR TITLE
refactor: extract PortMixin to eliminate duplicated port properties

### DIFF
--- a/src/programmatic_drafting/models/ports.py
+++ b/src/programmatic_drafting/models/ports.py
@@ -1,0 +1,29 @@
+"""Shared port geometry helpers for vessel port dataclasses."""
+
+from __future__ import annotations
+
+from math import radians
+
+
+class PortMixin:
+    """Mixin providing shared port geometry properties.
+
+    Inheriting dataclasses must define the following fields:
+        clock_angle_degrees: float
+        diameter_in: float
+    """
+
+    clock_angle_degrees: float
+    diameter_in: float
+
+    @property
+    def normalized_clock_angle_degrees(self) -> float:
+        return self.clock_angle_degrees % 360.0
+
+    @property
+    def normalized_clock_angle_radians(self) -> float:
+        return radians(self.normalized_clock_angle_degrees)
+
+    @property
+    def radius_in(self) -> float:
+        return self.diameter_in * 0.5

--- a/src/programmatic_drafting/models/vessel_drafter.py
+++ b/src/programmatic_drafting/models/vessel_drafter.py
@@ -14,6 +14,7 @@ from programmatic_drafting.contracts import (
     require_nonnegative,
     require_positive,
 )
+from programmatic_drafting.models.ports import PortMixin
 from programmatic_drafting.models.vessel_materials import (
     DEFAULT_VESSEL_MATERIALS_BY_NAME,
     MaterialProperties,
@@ -85,7 +86,7 @@ class VesselElectrodePlacement:
 
 
 @dataclass(frozen=True)
-class VesselSidePort:
+class VesselSidePort(PortMixin):
     clock_angle_degrees: float
     diameter_in: float
     height_above_glass_surface_in: float
@@ -97,24 +98,12 @@ class VesselSidePort:
             self.height_above_glass_surface_in,
         )
 
-    @property
-    def normalized_clock_angle_degrees(self) -> float:
-        return self.clock_angle_degrees % 360.0
-
-    @property
-    def normalized_clock_angle_radians(self) -> float:
-        return radians(self.normalized_clock_angle_degrees)
-
-    @property
-    def radius_in(self) -> float:
-        return self.diameter_in * 0.5
-
     def centerline_height_in(self, layout: VesselDrafterLayout) -> float:
         return layout.glass_depth_in + self.height_above_glass_surface_in
 
 
 @dataclass(frozen=True)
-class VesselLidPort:
+class VesselLidPort(PortMixin):
     clock_angle_degrees: float
     diameter_in: float
     radial_distance_from_center_in: float
@@ -125,18 +114,6 @@ class VesselLidPort:
             "radial_distance_from_center_in",
             self.radial_distance_from_center_in,
         )
-
-    @property
-    def normalized_clock_angle_degrees(self) -> float:
-        return self.clock_angle_degrees % 360.0
-
-    @property
-    def normalized_clock_angle_radians(self) -> float:
-        return radians(self.normalized_clock_angle_degrees)
-
-    @property
-    def radius_in(self) -> float:
-        return self.diameter_in * 0.5
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- Extracts shared port geometry properties (`normalized_clock_angle_degrees`, `normalized_clock_angle_radians`, `radius_in`) into a new `PortMixin` class in `src/programmatic_drafting/models/ports.py`.
- `VesselSidePort` and `VesselLidPort` now inherit from `PortMixin` and no longer duplicate the three properties.
- Public API preserved: same property names, same return types, same field layouts.

Fixes #22

## Test plan
- [x] `python3 -m ruff check .` clean
- [x] `python3 -m ruff format --check .` clean
- [x] `pytest tests/test_vessel_drafter_defaults.py` passes (3/3)
- [x] Manual smoke test confirms `isinstance(port, PortMixin)` works, MRO is `[VesselSidePort, PortMixin, object]`, and normalized angles / `radius_in` return identical values to prior implementation.

Generated with Claude Code