### PR TITLE
refactor: decompose oversized rendering/mesh functions

### DIFF
--- a/src/programmatic_drafting/gui/vessel_drafter_rendering.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_rendering.py
@@ -41,6 +41,16 @@ def render_cross_section(scene: QGraphicsScene, preview: CrossSectionPreview) ->
             PREVIEW_MARGIN + ((top_z_in - point.z_in) * PREVIEW_SCALE),
         )
 
+    _render_bands_and_plenum(scene, preview, map_point)
+    _render_axial_electrodes(scene, preview, center_x, top_z_in)
+    _render_projected_side_ports(scene, preview, center_x, top_z_in)
+
+
+def _render_bands_and_plenum(
+    scene: QGraphicsScene,
+    preview: CrossSectionPreview,
+    map_point,
+) -> None:
     for z_value, polygon in enumerate(preview.band_polygons, start=1):
         _add_band_polygon(scene, polygon, map_point, float(z_value))
 
@@ -55,6 +65,13 @@ def render_cross_section(scene: QGraphicsScene, preview: CrossSectionPreview) ->
     plenum_item.setZValue(10.0)
     scene.addItem(plenum_item)
 
+
+def _render_axial_electrodes(
+    scene: QGraphicsScene,
+    preview: CrossSectionPreview,
+    center_x: float,
+    top_z_in: float,
+) -> None:
     for feature in preview.axial_electrodes:
         radius_px = feature.diameter_in * 0.5 * PREVIEW_SCALE
         y = PREVIEW_MARGIN + ((top_z_in - feature.centerline_height_in) * PREVIEW_SCALE)
@@ -70,6 +87,13 @@ def render_cross_section(scene: QGraphicsScene, preview: CrossSectionPreview) ->
         )
         _add_path(scene, path, feature.color_hex, 20.0)
 
+
+def _render_projected_side_ports(
+    scene: QGraphicsScene,
+    preview: CrossSectionPreview,
+    center_x: float,
+    top_z_in: float,
+) -> None:
     for port in preview.projected_side_ports:
         center_y = PREVIEW_MARGIN + (
             (top_z_in - port.centerline_height_in) * PREVIEW_SCALE

--- a/src/programmatic_drafting/preview/vessel_drafter_scene.py
+++ b/src/programmatic_drafting/preview/vessel_drafter_scene.py
@@ -301,6 +301,25 @@ def _revolved_profile_mesh(
     view_options: Vessel3DViewOptions,
 ) -> tuple[FloatArray, IntArray]:
     angles = _preview_angles(view_options)
+    vertices, vertex_groups = _build_revolved_vertices(half_profile, angles)
+    face_parts = _build_revolved_faces(vertex_groups, view_options)
+    if view_options.split_enabled:
+        section_vertices, section_faces = _section_cap_mesh(
+            half_profile,
+            view_options,
+        )
+        if section_faces.size > 0:
+            section_faces = section_faces + len(vertices)
+            vertices = np.vstack((vertices, section_vertices))
+            face_parts.append(section_faces)
+    faces = np.vstack(face_parts)
+    return vertices, faces
+
+
+def _build_revolved_vertices(
+    half_profile: tuple[ProfilePoint, ...],
+    angles: FloatArray,
+) -> tuple[FloatArray, list[int | IntArray]]:
     angle_count = len(angles)
     cos_theta = np.cos(angles)
     sin_theta = np.sin(angles)
@@ -331,8 +350,14 @@ def _revolved_profile_mesh(
         vertex_parts.append(ring)
         vertex_count += angle_count
 
-    vertices = np.vstack(vertex_parts)
-    face_parts = []
+    return np.vstack(vertex_parts), vertex_groups
+
+
+def _build_revolved_faces(
+    vertex_groups: list[int | IntArray],
+    view_options: Vessel3DViewOptions,
+) -> list[IntArray]:
+    face_parts: list[IntArray] = []
     for start_group, end_group in _profile_segments(vertex_groups):
         segment_faces = _segment_faces(
             start_group,
@@ -341,17 +366,7 @@ def _revolved_profile_mesh(
         )
         if segment_faces.size > 0:
             face_parts.append(segment_faces)
-    if view_options.split_enabled:
-        section_vertices, section_faces = _section_cap_mesh(
-            half_profile,
-            view_options,
-        )
-        if section_faces.size > 0:
-            section_faces = section_faces + len(vertices)
-            vertices = np.vstack((vertices, section_vertices))
-            face_parts.append(section_faces)
-    faces = np.vstack(face_parts)
-    return vertices, faces
+    return face_parts
 
 
 def _profile_segments(
@@ -416,6 +431,22 @@ def _cylinder_mesh(
     end_point: FloatArray,
     radius_in: float,
 ) -> tuple[FloatArray, IntArray]:
+    radial_unit, binormal_unit = _cylinder_axis_frame(start_point, end_point)
+    vertices = _cylinder_vertices(
+        start_point,
+        end_point,
+        radius_in,
+        radial_unit,
+        binormal_unit,
+    )
+    faces = _cylinder_faces()
+    return vertices, faces
+
+
+def _cylinder_axis_frame(
+    start_point: FloatArray,
+    end_point: FloatArray,
+) -> tuple[FloatArray, FloatArray]:
     axis_vector = end_point - start_point
     axis_length = np.linalg.norm(axis_vector)
     axis_unit = axis_vector / axis_length
@@ -425,7 +456,16 @@ def _cylinder_mesh(
     radial_unit = np.cross(axis_unit, reference)
     radial_unit /= np.linalg.norm(radial_unit)
     binormal_unit = np.cross(axis_unit, radial_unit)
+    return radial_unit, binormal_unit
 
+
+def _cylinder_vertices(
+    start_point: FloatArray,
+    end_point: FloatArray,
+    radius_in: float,
+    radial_unit: FloatArray,
+    binormal_unit: FloatArray,
+) -> FloatArray:
     angles = np.linspace(
         0.0,
         2.0 * pi,
@@ -445,8 +485,10 @@ def _cylinder_mesh(
     ) * radius_in
     start_ring = start_point[np.newaxis, :] + radial_offsets
     end_ring = end_point[np.newaxis, :] + radial_offsets
-    vertices = np.vstack((start_ring, end_ring, start_point, end_point))
+    return np.vstack((start_ring, end_ring, start_point, end_point))
 
+
+def _cylinder_faces() -> IntArray:
     lower_indices = np.arange(DEFAULT_ELECTRODE_SEGMENTS, dtype=np.int32)
     upper_indices = lower_indices + DEFAULT_ELECTRODE_SEGMENTS
     start_center_index = np.int32(DEFAULT_ELECTRODE_SEGMENTS * 2)
@@ -477,7 +519,7 @@ def _cylinder_mesh(
             np.roll(upper_indices, -1),
         )
     )
-    return vertices, np.vstack((side_faces, start_cap, end_cap))
+    return np.vstack((side_faces, start_cap, end_cap))
 
 
 def _preview_angles(view_options: Vessel3DViewOptions) -> FloatArray:


### PR DESCRIPTION
## Summary
Decomposes the three oversized functions flagged in issue #24 into single-responsibility private helpers. State is passed through arguments (no closures), and public function signatures are preserved.

- `render_cross_section` (73 -> 23 LOC) split into `_render_bands_and_plenum`, `_render_axial_electrodes`, `_render_projected_side_ports`.
- `_revolved_profile_mesh` (55 -> 17 LOC) split into `_build_revolved_vertices` and `_build_revolved_faces`.
- `_cylinder_mesh` (66 -> 14 LOC) split into `_cylinder_axis_frame`, `_cylinder_vertices`, and `_cylinder_faces`.

All numerical/visual behaviour is preserved - helpers are pure extractions producing the same arrays in the same order.

Fixes #24

## Test plan
- [x] `python -m ruff check .` clean
- [x] `python -m ruff format --check .` clean
- [x] AST verification: all three target functions now under 40 LOC
- [ ] Full `pytest` run (local env missing `build123d`; CI will cover)

Generated with Claude Code