### PR TITLE
chore: force self-hosted runners to conserve github action minutes

### DIFF
--- a/.github/workflows/ci-failure-digest.yml
+++ b/.github/workflows/ci-failure-digest.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   generate-digest:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   quality-gate:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       QT_QPA_PLATFORM: offscreen
     steps:
@@ -32,7 +32,7 @@ jobs:
 
   tests:
     needs: quality-gate
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       QT_QPA_PLATFORM: offscreen
     steps:

--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check-size:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/weekly-cad-sweep.yml
+++ b/.github/workflows/weekly-cad-sweep.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   regenerate-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       QT_QPA_PLATFORM: offscreen
     steps:


### PR DESCRIPTION
By bypassing ubuntu-latest and the pick-runner dispatcher, we forcibly route all jobs to self-hosted runners entirely, eliminating GitHub cloud Action minute consumption. This change is entirely reversible via git revert or mass sed replacement.