### PR TITLE
[codex] Validate vessel port clock angles are finite

### DIFF
--- a/src/programmatic_drafting/models/vessel_drafter.py
+++ b/src/programmatic_drafting/models/vessel_drafter.py
@@ -9,6 +9,7 @@ from typing import Any
 from programmatic_drafting.constants import MM_PER_INCH
 from programmatic_drafting.contracts import (
     require_fraction,
+    require_finite,
     require_integer_at_least,
     require_less_or_equal,
     require_nonnegative,
@@ -92,6 +93,7 @@ class VesselSidePort(PortMixin):
     height_above_glass_surface_in: float
 
     def __post_init__(self) -> None:
+        require_finite("clock_angle_degrees", self.clock_angle_degrees)
         require_positive("diameter_in", self.diameter_in)
         require_nonnegative(
             "height_above_glass_surface_in",
@@ -109,6 +111,7 @@ class VesselLidPort(PortMixin):
     radial_distance_from_center_in: float
 
     def __post_init__(self) -> None:
+        require_finite("clock_angle_degrees", self.clock_angle_degrees)
         require_positive("diameter_in", self.diameter_in)
         require_nonnegative(
             "radial_distance_from_center_in",

--- a/src/programmatic_drafting/models/vessel_drafter.py
+++ b/src/programmatic_drafting/models/vessel_drafter.py
@@ -8,8 +8,8 @@ from typing import Any
 
 from programmatic_drafting.constants import MM_PER_INCH
 from programmatic_drafting.contracts import (
-    require_fraction,
     require_finite,
+    require_fraction,
     require_integer_at_least,
     require_less_or_equal,
     require_nonnegative,

--- a/tests/test_vessel_drafter_defaults.py
+++ b/tests/test_vessel_drafter_defaults.py
@@ -92,3 +92,23 @@ def test_invalid_dimensions_raise_value_error() -> None:
                 ),
             )
         )
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_side_port_rejects_non_finite_clock_angle(value: float) -> None:
+    with pytest.raises(ValueError, match="clock_angle_degrees"):
+        VesselSidePort(
+            clock_angle_degrees=value,
+            diameter_in=2.0,
+            height_above_glass_surface_in=1.0,
+        )
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_lid_port_rejects_non_finite_clock_angle(value: float) -> None:
+    with pytest.raises(ValueError, match="clock_angle_degrees"):
+        VesselLidPort(
+            clock_angle_degrees=value,
+            diameter_in=2.0,
+            radial_distance_from_center_in=1.0,
+        )


### PR DESCRIPTION
## Summary
- Validate side-port and lid-port clock angles are finite before normalizing them.
- Add regression tests for NaN and infinity clock angles.

Closes #38

## Validation
- `TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/test_vessel_drafter_defaults.py -q`
