### PR TITLE
Decompose vessel drafter manifest builders

### DIFF
--- a/src/programmatic_drafting/models/vessel_drafter.py
+++ b/src/programmatic_drafting/models/vessel_drafter.py
@@ -334,86 +334,141 @@ class VesselDrafterLayout:
         return {
             "project": "vessel_drafter_default",
             "units": {"source": "inches", "cad": "millimeters"},
-            "vessel": {
-                "inner_diameter_in": self.inner_diameter_in,
-                "glass_depth_in": self.glass_depth_in,
-                "plenum_height_in": self.plenum_height_in,
-                "head_depth_in": self.head_depth_in,
-                "outer_diameter_in": self.outer_diameter_in,
-                "full_height_in": self.full_height_in,
-                "outer_head_depth_in": self.outer_head_depth_in,
-            },
-            "materials": {
-                layer.name: {
-                    "thickness_in": layer.thickness_in,
-                    "display_name": layer.display_name,
-                    "color_hex": layer.color_hex,
-                    "density_lb_per_ft3": layer.density_lb_per_ft3,
-                    "thermal_conductivity_w_per_mk": (
-                        layer.thermal_conductivity_w_per_mk
-                    ),
-                    "thermal_expansion_um_per_m_c": (
-                        layer.thermal_expansion_um_per_m_c
-                    ),
-                }
-                for layer in self.layers[1:]
-            },
-            "glass_bath": {
-                "display_name": self.layers[0].display_name,
-                "color_hex": self.layers[0].color_hex,
-                "height_in": self.glass_depth_in,
-                "density_lb_per_ft3": self.layers[0].density_lb_per_ft3,
-                "thermal_conductivity_w_per_mk": (
-                    self.layers[0].thermal_conductivity_w_per_mk
-                ),
-                "thermal_expansion_um_per_m_c": (
-                    self.layers[0].thermal_expansion_um_per_m_c
-                ),
-            },
-            "electrodes": {
-                "count": self.electrode_count,
-                "diameter_in": self.electrode_diameter_in,
-                "insertion_into_inner_circle_in": (
-                    self.electrode_insertion_into_inner_circle_in
-                ),
-                "extension_past_inner_circle_in": (
-                    self.electrode_extension_past_inner_circle_in
-                ),
-                "modeled_length_in": self.electrode_length_in,
-                "centerline_height_in": self.electrode_centerline_height_in,
-            },
-            "ports": {
-                "side": [
-                    {
-                        "clock_angle_degrees": port.normalized_clock_angle_degrees,
-                        "diameter_in": port.diameter_in,
-                        "height_above_glass_surface_in": (
-                            port.height_above_glass_surface_in
-                        ),
-                        "centerline_height_in": port.centerline_height_in(self),
-                    }
-                    for port in self.side_ports
-                ],
-                "lid": [
-                    {
-                        "clock_angle_degrees": port.normalized_clock_angle_degrees,
-                        "diameter_in": port.diameter_in,
-                        "radial_distance_from_center_in": (
-                            port.radial_distance_from_center_in
-                        ),
-                    }
-                    for port in self.lid_ports
-                ],
-            },
-            "drafting_assumptions": {
-                "axis_convention": "Z up",
-                "plenum_only_internal_void": True,
-                "dished_heads": (
-                    "Offset elliptical head profiles with "
-                    "constant-thickness shell layers"
-                ),
-            },
+            "vessel": _build_vessel_manifest(self),
+            "materials": _build_shell_materials_manifest(self.layers[1:]),
+            "glass_bath": _build_glass_bath_manifest(
+                self.layers[0], self.glass_depth_in
+            ),
+            "electrodes": _build_electrodes_manifest(self),
+            "ports": _build_ports_manifest(self),
+            "drafting_assumptions": _build_drafting_assumptions_manifest(),
         }
+
+
+def _build_vessel_manifest(layout: VesselDrafterLayout) -> dict[str, Any]:
+    """Build the vessel geometry section for a manifest.
+
+    Preconditions:
+        layout must be a validated VesselDrafterLayout.
+    """
+    return {
+        "inner_diameter_in": layout.inner_diameter_in,
+        "glass_depth_in": layout.glass_depth_in,
+        "plenum_height_in": layout.plenum_height_in,
+        "head_depth_in": layout.head_depth_in,
+        "outer_diameter_in": layout.outer_diameter_in,
+        "full_height_in": layout.full_height_in,
+        "outer_head_depth_in": layout.outer_head_depth_in,
+    }
+
+
+def _build_shell_materials_manifest(
+    layers: tuple[MaterialLayer, ...],
+) -> dict[str, Any]:
+    """Build the material section for the shell layers."""
+    return {layer.name: _build_material_manifest(layer) for layer in layers}
+
+
+def _build_material_manifest(layer: MaterialLayer) -> dict[str, Any]:
+    """Build one shell material manifest entry.
+
+    Preconditions:
+        layer must be a validated MaterialLayer.
+    """
+    return {
+        "thickness_in": layer.thickness_in,
+        "display_name": layer.display_name,
+        "color_hex": layer.color_hex,
+        "density_lb_per_ft3": layer.density_lb_per_ft3,
+        "thermal_conductivity_w_per_mk": layer.thermal_conductivity_w_per_mk,
+        "thermal_expansion_um_per_m_c": layer.thermal_expansion_um_per_m_c,
+    }
+
+
+def _build_glass_bath_manifest(
+    layer: MaterialLayer,
+    height_in: float,
+) -> dict[str, Any]:
+    """Build the glass bath manifest entry.
+
+    Preconditions:
+        layer must be the validated glass bath layer for the layout.
+        height_in must match the layout's glass depth.
+    """
+    return {
+        "display_name": layer.display_name,
+        "color_hex": layer.color_hex,
+        "height_in": height_in,
+        "density_lb_per_ft3": layer.density_lb_per_ft3,
+        "thermal_conductivity_w_per_mk": layer.thermal_conductivity_w_per_mk,
+        "thermal_expansion_um_per_m_c": layer.thermal_expansion_um_per_m_c,
+    }
+
+
+def _build_electrodes_manifest(layout: VesselDrafterLayout) -> dict[str, Any]:
+    """Build the electrode manifest section."""
+    return {
+        "count": layout.electrode_count,
+        "diameter_in": layout.electrode_diameter_in,
+        "insertion_into_inner_circle_in": (
+            layout.electrode_insertion_into_inner_circle_in
+        ),
+        "extension_past_inner_circle_in": (
+            layout.electrode_extension_past_inner_circle_in
+        ),
+        "modeled_length_in": layout.electrode_length_in,
+        "centerline_height_in": layout.electrode_centerline_height_in,
+    }
+
+
+def _build_ports_manifest(layout: VesselDrafterLayout) -> dict[str, Any]:
+    """Build the side and lid port manifest sections."""
+    return {
+        "side": [_build_side_port_manifest(layout, port) for port in layout.side_ports],
+        "lid": [_build_lid_port_manifest(port) for port in layout.lid_ports],
+    }
+
+
+def _build_side_port_manifest(
+    layout: VesselDrafterLayout,
+    port: VesselSidePort,
+) -> dict[str, Any]:
+    """Build one side-port manifest entry.
+
+    Preconditions:
+        layout must be a validated VesselDrafterLayout.
+        port must be a validated VesselSidePort associated with the layout.
+    """
+    return {
+        "clock_angle_degrees": port.normalized_clock_angle_degrees,
+        "diameter_in": port.diameter_in,
+        "height_above_glass_surface_in": port.height_above_glass_surface_in,
+        "centerline_height_in": port.centerline_height_in(layout),
+    }
+
+
+def _build_lid_port_manifest(port: VesselLidPort) -> dict[str, Any]:
+    """Build one lid-port manifest entry.
+
+    Preconditions:
+        port must be a validated VesselLidPort.
+    """
+    return {
+        "clock_angle_degrees": port.normalized_clock_angle_degrees,
+        "diameter_in": port.diameter_in,
+        "radial_distance_from_center_in": port.radial_distance_from_center_in,
+    }
+
+
+def _build_drafting_assumptions_manifest() -> dict[str, Any]:
+    """Build the fixed drafting assumptions section."""
+    return {
+        "axis_convention": "Z up",
+        "plenum_only_internal_void": True,
+        "dished_heads": (
+            "Offset elliptical head profiles with " "constant-thickness shell layers"
+        ),
+    }
 
 
 DEFAULT_VESSEL_DRAFTER_LAYOUT = VesselDrafterLayout()

--- a/tests/test_vessel_drafter_manifest.py
+++ b/tests/test_vessel_drafter_manifest.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from programmatic_drafting.models.vessel_drafter import (
+    DEFAULT_VESSEL_DRAFTER_LAYOUT,
+    VesselDrafterLayout,
+    VesselLidPort,
+    VesselSidePort,
+    _build_drafting_assumptions_manifest,
+    _build_glass_bath_manifest,
+    _build_lid_port_manifest,
+    _build_ports_manifest,
+    _build_shell_materials_manifest,
+    _build_side_port_manifest,
+    _build_vessel_manifest,
+)
+
+
+def test_build_vessel_manifest_reports_layout_geometry() -> None:
+    manifest = _build_vessel_manifest(DEFAULT_VESSEL_DRAFTER_LAYOUT)
+
+    assert manifest["inner_diameter_in"] == 50.0
+    assert manifest["outer_diameter_in"] == 74.0
+    assert manifest["full_height_in"] == DEFAULT_VESSEL_DRAFTER_LAYOUT.full_height_in
+
+
+def test_build_shell_materials_manifest_includes_shell_layers() -> None:
+    materials = _build_shell_materials_manifest(
+        DEFAULT_VESSEL_DRAFTER_LAYOUT.layers[1:]
+    )
+
+    assert set(materials) == {
+        "hot_face_refractory",
+        "ifb",
+        "duraboard",
+        "steel_shell",
+    }
+    assert materials["steel_shell"]["thickness_in"] == 0.5
+    assert materials["steel_shell"]["display_name"] == "Steel Shell"
+
+
+def test_build_glass_bath_manifest_uses_glass_layer_properties() -> None:
+    layer = DEFAULT_VESSEL_DRAFTER_LAYOUT.layers[0]
+
+    manifest = _build_glass_bath_manifest(
+        layer,
+        DEFAULT_VESSEL_DRAFTER_LAYOUT.glass_depth_in,
+    )
+
+    assert manifest["display_name"] == "Glass Bath"
+    assert manifest["height_in"] == 14.0
+    assert manifest["color_hex"] == layer.color_hex
+
+
+def test_build_port_manifest_helpers_track_layout_geometry() -> None:
+    layout = VesselDrafterLayout(
+        side_ports=(
+            VesselSidePort(
+                clock_angle_degrees=45.0,
+                diameter_in=3.0,
+                height_above_glass_surface_in=4.0,
+            ),
+        ),
+        lid_ports=(
+            VesselLidPort(
+                clock_angle_degrees=180.0,
+                diameter_in=4.0,
+                radial_distance_from_center_in=6.0,
+            ),
+        ),
+    )
+
+    side_port = _build_side_port_manifest(layout, layout.side_ports[0])
+    lid_port = _build_lid_port_manifest(layout.lid_ports[0])
+    ports = _build_ports_manifest(layout)
+
+    assert side_port["centerline_height_in"] == 18.0
+    assert lid_port["radial_distance_from_center_in"] == 6.0
+    assert ports["side"][0] == side_port
+    assert ports["lid"][0] == lid_port
+
+
+def test_build_drafting_assumptions_manifest_is_stable() -> None:
+    manifest = _build_drafting_assumptions_manifest()
+
+    assert manifest == {
+        "axis_convention": "Z up",
+        "plenum_only_internal_void": True,
+        "dished_heads": (
+            "Offset elliptical head profiles with " "constant-thickness shell layers"
+        ),
+    }


### PR DESCRIPTION
Refactors `VesselDrafterLayout.to_manifest` into smaller manifest builders and adds focused unit tests for the new helpers.

This is a bounded slice of the oversized-function work tracked in #26 and #32.

Validation:
- .venv/bin/pytest tests/test_vessel_drafter_manifest.py tests/test_vessel_drafter_export.py -q
- .venv/bin/ruff check src/programmatic_drafting/models/vessel_drafter.py tests/test_vessel_drafter_manifest.py
- .venv/bin/black --check src/programmatic_drafting/models/vessel_drafter.py tests/test_vessel_drafter_manifest.py