### PR TITLE
refactor: split cylindrical bath manifest helpers

### DIFF
--- a/src/programmatic_drafting/models/cylindrical_bath.py
+++ b/src/programmatic_drafting/models/cylindrical_bath.py
@@ -93,50 +93,65 @@ class CylindricalBathLayout:
         return {
             "project": "cylindrical_bath_layout",
             "units": {"source": "inches", "cad": "millimeters"},
-            "bath": {
-                "shape": "cylindrical",
-                "inner_diameter_in": self.bath.inner_diameter_in,
-                "depth_in": self.bath.depth_in,
-                "refractory_thickness_in": self.bath.refractory_thickness_in,
-                "outer_diameter_in": self.bath.inner_diameter_in
-                + (2.0 * self.bath.refractory_thickness_in),
-            },
-            "electrodes": {
-                "count": self.electrodes.count,
-                "diameter_in": self.electrodes.diameter_in,
-                "insertion_into_inner_circle_in": (
-                    self.electrodes.insertion_into_inner_circle_in
-                ),
-                "extension_past_inner_circle_in": (
-                    self.electrodes.extension_past_inner_circle_in
-                ),
-                "modeled_length_in": (
-                    self.electrodes.insertion_into_inner_circle_in
-                    + self.electrodes.extension_past_inner_circle_in
-                ),
-                "center_height_fraction": self.electrodes.center_height_fraction,
-            },
-            "drafting_assumptions": {
-                "axis_convention": "Z up",
-                "electrodes_centered_vertically": True,
-                "electrode_tip_reference": (
-                    "Modeled from the inner-wall penetration tip to the external end."
-                ),
-                "conflicting_length_note_ignored": (
-                    "Used explicit 14 in insertion and 36 in extension values."
-                ),
-            },
-            "placements": [
-                {
-                    "index": item.index,
-                    "angle_degrees": item.angle_degrees,
-                    "center_mm": [item.center_x_mm, item.center_y_mm, 0.0],
-                    "inner_tip_mm": [item.inner_tip_x_mm, item.inner_tip_y_mm, 0.0],
-                    "outer_tip_mm": [item.outer_tip_x_mm, item.outer_tip_y_mm, 0.0],
-                }
-                for item in self.placements
-            ],
+            "bath": _build_bath_manifest(self.bath),
+            "electrodes": _build_electrodes_manifest(self.electrodes),
+            "drafting_assumptions": _build_drafting_manifest(),
+            "placements": [_build_placement_manifest(item) for item in self.placements],
         }
+
+
+def _build_bath_manifest(bath: CylindricalBathDefaults) -> dict[str, Any]:
+    """Build the bath geometry section for a manifest."""
+    return {
+        "shape": "cylindrical",
+        "inner_diameter_in": bath.inner_diameter_in,
+        "depth_in": bath.depth_in,
+        "refractory_thickness_in": bath.refractory_thickness_in,
+        "outer_diameter_in": bath.inner_diameter_in
+        + (2.0 * bath.refractory_thickness_in),
+    }
+
+
+def _build_electrodes_manifest(
+    electrodes: CylindricalElectrodeDefaults,
+) -> dict[str, Any]:
+    """Build the radial electrode defaults section for a manifest."""
+    return {
+        "count": electrodes.count,
+        "diameter_in": electrodes.diameter_in,
+        "insertion_into_inner_circle_in": electrodes.insertion_into_inner_circle_in,
+        "extension_past_inner_circle_in": electrodes.extension_past_inner_circle_in,
+        "modeled_length_in": (
+            electrodes.insertion_into_inner_circle_in
+            + electrodes.extension_past_inner_circle_in
+        ),
+        "center_height_fraction": electrodes.center_height_fraction,
+    }
+
+
+def _build_drafting_manifest() -> dict[str, Any]:
+    """Build drafting assumptions for the cylindrical bath manifest."""
+    return {
+        "axis_convention": "Z up",
+        "electrodes_centered_vertically": True,
+        "electrode_tip_reference": (
+            "Modeled from the inner-wall penetration tip to the external end."
+        ),
+        "conflicting_length_note_ignored": (
+            "Used explicit 14 in insertion and 36 in extension values."
+        ),
+    }
+
+
+def _build_placement_manifest(item: RadialElectrodePlacement) -> dict[str, Any]:
+    """Build one radial electrode placement entry for a manifest."""
+    return {
+        "index": item.index,
+        "angle_degrees": item.angle_degrees,
+        "center_mm": [item.center_x_mm, item.center_y_mm, 0.0],
+        "inner_tip_mm": [item.inner_tip_x_mm, item.inner_tip_y_mm, 0.0],
+        "outer_tip_mm": [item.outer_tip_x_mm, item.outer_tip_y_mm, 0.0],
+    }
 
 
 def _build_default_placements(

--- a/tests/test_cylindrical_bath_manifest.py
+++ b/tests/test_cylindrical_bath_manifest.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+from programmatic_drafting.models.cylindrical_bath import (
+    DEFAULT_CYLINDRICAL_BATH_LAYOUT,
+    _build_bath_manifest,
+    _build_drafting_manifest,
+    _build_electrodes_manifest,
+    _build_placement_manifest,
+)
+
+
+def test_bath_manifest_reports_inner_and_outer_geometry() -> None:
+    manifest = _build_bath_manifest(DEFAULT_CYLINDRICAL_BATH_LAYOUT.bath)
+
+    assert manifest["shape"] == "cylindrical"
+    assert manifest["inner_diameter_in"] == pytest.approx(50.0)
+    assert manifest["outer_diameter_in"] == pytest.approx(62.0)
+
+
+def test_electrodes_manifest_reports_modeled_length() -> None:
+    manifest = _build_electrodes_manifest(DEFAULT_CYLINDRICAL_BATH_LAYOUT.electrodes)
+
+    assert manifest["count"] == 3
+    assert manifest["modeled_length_in"] == pytest.approx(50.0)
+    assert manifest["center_height_fraction"] == pytest.approx(0.5)
+
+
+def test_drafting_manifest_documents_reference_assumptions() -> None:
+    manifest = _build_drafting_manifest()
+
+    assert manifest["axis_convention"] == "Z up"
+    assert manifest["electrodes_centered_vertically"] is True
+
+
+def test_placement_manifest_reports_radial_points() -> None:
+    manifest = _build_placement_manifest(DEFAULT_CYLINDRICAL_BATH_LAYOUT.placements[0])
+
+    assert manifest["index"] == 1
+    assert len(manifest["center_mm"]) == 3
+    assert len(manifest["inner_tip_mm"]) == 3
+    assert len(manifest["outer_tip_mm"]) == 3


### PR DESCRIPTION
## Summary
- split cylindrical bath manifest assembly into focused helper functions
- add manifest-level tests for bath, electrodes, drafting envelope, and radial placements

## Validation
- `TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/test_cylindrical_bath_manifest.py -q`
- `python3 -m ruff check src/programmatic_drafting/models/cylindrical_bath.py tests/test_cylindrical_bath_manifest.py`
- `python3 -m black --check src/programmatic_drafting/models/cylindrical_bath.py tests/test_cylindrical_bath_manifest.py`

Refs #26
