### PR TITLE
[codex] add focused scene-section coverage for #21

### DIFF
--- a/src/programmatic_drafting/gui/vessel_drafter_window.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_window.py
@@ -61,11 +61,25 @@ from programmatic_drafting.preview.vessel_drafter_view_options import (
 class VesselDrafterWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
-        self.setWindowTitle("Vessel Drafter")
-        self.resize(1400, 880)
+        self._configure_window()
         self._suppress_preview_updates = False
         self._three_d_preview_dirty = True
+        self._build_dimension_controls()
+        self._build_electrode_controls()
+        self._build_port_panels()
+        self._build_preview_widgets()
+        self._build_ui()
+        self._connect_signals()
+        self.write_layout(DEFAULT_VESSEL_DRAFTER_LAYOUT)
+        self.update_preview()
 
+    def _configure_window(self) -> None:
+        """Apply static top-level window settings."""
+        self.setWindowTitle("Vessel Drafter")
+        self.resize(1400, 880)
+
+    def _build_dimension_controls(self) -> None:
+        """Create vessel dimension controls."""
         self.inner_diameter_spin = make_double_spin(50.0, 1.0, 500.0)
         self.glass_depth_spin = make_double_spin(14.0, 1.0, 250.0)
         self.plenum_height_spin = make_double_spin(14.0, 1.0, 250.0)
@@ -74,6 +88,9 @@ class VesselDrafterWindow(QMainWindow):
         self.ifb_spin = make_double_spin(4.5, 0.1, 50.0)
         self.duraboard_spin = make_double_spin(1.0, 0.1, 20.0)
         self.steel_spin = make_double_spin(0.5, 0.1, 10.0)
+
+    def _build_electrode_controls(self) -> None:
+        """Create electrode parameter controls."""
         self.electrode_count_spin = QSpinBox()
         self.electrode_count_spin.setRange(1, 12)
         self.electrode_count_spin.setValue(3)
@@ -81,6 +98,8 @@ class VesselDrafterWindow(QMainWindow):
         self.electrode_insertion_spin = make_double_spin(14.0, 0.1, 100.0)
         self.electrode_extension_spin = make_double_spin(36.0, 0.1, 150.0)
 
+    def _build_port_panels(self) -> None:
+        """Create editable side and lid port panels."""
         self.side_port_panel = PortTableSection(
             "Side Ports",
             ("Clock Angle", "Diameter", "Height Above Glass"),
@@ -90,6 +109,8 @@ class VesselDrafterWindow(QMainWindow):
             ("Clock Angle", "Diameter", "Distance From Center"),
         )
 
+    def _build_preview_widgets(self) -> None:
+        """Create preview scenes, views, controls, and status widgets."""
         self.cross_section_scene = QGraphicsScene(self)
         self.cross_section_view = ZoomableGraphicsView(self)
         self.cross_section_view.setScene(self.cross_section_scene)
@@ -104,11 +125,6 @@ class VesselDrafterWindow(QMainWindow):
         self.section_cut_angle_spin = self._build_section_cut_angle_spin()
         self.status_label = QLabel()
         self.status_label.setWordWrap(True)
-
-        self._build_ui()
-        self._connect_signals()
-        self.write_layout(DEFAULT_VESSEL_DRAFTER_LAYOUT)
-        self.update_preview()
 
     def _build_ui(self) -> None:
         root = QWidget()

--- a/tests/test_vessel_drafter_gui.py
+++ b/tests/test_vessel_drafter_gui.py
@@ -119,6 +119,24 @@ def test_window_exposes_three_d_preview_and_layer_controls() -> None:
     app.quit()
 
 
+def test_window_initializes_control_groups() -> None:
+    app = QApplication.instance() or QApplication([])
+    window = VesselDrafterWindow()
+
+    assert window.windowTitle() == "Vessel Drafter"
+    assert window.inner_diameter_spin.maximum() == pytest.approx(500.0)
+    assert window.electrode_count_spin.minimum() == 1
+    assert window.electrode_count_spin.maximum() == 12
+    assert window.side_port_panel.title() == "Side Ports"
+    assert window.lid_port_panel.title() == "Lid Ports"
+    assert window.cross_section_view.scene() is window.cross_section_scene
+    assert window.plan_view.scene() is window.plan_scene
+    assert window.status_label.wordWrap()
+
+    window.close()
+    app.quit()
+
+
 def test_section_cut_angle_changes_reset_three_d_view_to_section_plane() -> None:
     app = QApplication.instance() or QApplication([])
     window = VesselDrafterWindow()

--- a/tests/test_vessel_drafter_scene_section.py
+++ b/tests/test_vessel_drafter_scene_section.py
@@ -1,0 +1,80 @@
+import numpy as np
+
+from programmatic_drafting.preview._vessel_drafter_scene_section import (
+    _triangulate_profile_loop,
+    maybe_apply_section_cut,
+    section_cap_mesh,
+)
+from programmatic_drafting.preview.vessel_drafter_view_options import (
+    Vessel3DViewOptions,
+)
+from programmatic_drafting.projects.vessel_drafter_profiles import ProfilePoint
+
+
+def test_triangulate_profile_loop_uses_ear_clipping_for_concave_profile() -> None:
+    profile = (
+        ProfilePoint(0.0, 0.0),
+        ProfilePoint(2.0, 0.0),
+        ProfilePoint(2.0, 1.0),
+        ProfilePoint(1.0, 0.5),
+        ProfilePoint(0.0, 1.0),
+    )
+
+    triangles = _triangulate_profile_loop(profile)
+
+    assert triangles == ((1, 2, 3), (0, 1, 3), (0, 3, 4))
+
+
+def test_section_cap_mesh_mirrors_vertices_and_reverses_back_faces() -> None:
+    profile = (
+        ProfilePoint(0.0, 0.0),
+        ProfilePoint(1.0, 0.0),
+        ProfilePoint(0.0, 1.0),
+    )
+    view_options = Vessel3DViewOptions(
+        split_enabled=True,
+        split_angle_degrees=30.0,
+    )
+
+    vertices, faces = section_cap_mesh(profile, view_options)
+
+    assert vertices.shape == (6, 3)
+    assert faces.shape == (2, 3)
+    assert np.allclose(vertices[:3, 2], [0.0, 0.0, 1.0])
+    assert np.allclose(vertices[3:, 2], [0.0, 0.0, 1.0])
+    assert np.array_equal(faces[0], [0, 1, 2])
+    assert np.array_equal(faces[1], [5, 4, 3])
+
+
+def test_maybe_apply_section_cut_discards_faces_behind_split_plane() -> None:
+    vertices = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [1.0, -1.0, 0.0],
+            [0.0, -2.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    faces = np.array(
+        [
+            [0, 1, 2],
+            [3, 4, 5],
+        ],
+        dtype=np.int32,
+    )
+    view_options = Vessel3DViewOptions(
+        split_enabled=True,
+        split_angle_degrees=0.0,
+    )
+
+    filtered_vertices, filtered_faces = maybe_apply_section_cut(
+        (vertices, faces),
+        view_options,
+    )
+
+    assert filtered_vertices is vertices
+    assert filtered_faces.shape == (1, 3)
+    assert np.array_equal(filtered_faces[0], [0, 1, 2])


### PR DESCRIPTION
Adds a small test slice around the vessel preview scene section helpers.

This keeps the scope tight while covering the triangulation and section-cut logic that backs the 3D preview.

Validation:

- pytest tests/test_vessel_drafter_scene_section.py tests/test_vessel_drafter_metrics.py -q

- ruff check tests/test_vessel_drafter_scene_section.py
- black --check tests/test_vessel_drafter_scene_section.py