### PR TITLE
refactor: split projected side port rendering

### DIFF
--- a/src/programmatic_drafting/gui/vessel_drafter_rendering.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_rendering.py
@@ -14,6 +14,7 @@ from programmatic_drafting.preview.vessel_drafter_preview import (
     PlanCircularFeature,
     PlanPreview,
     PlanRadialFeature,
+    ProjectedSidePort,
 )
 from programmatic_drafting.projects.vessel_drafter_profiles import ProfilePoint
 
@@ -95,29 +96,52 @@ def _render_projected_side_ports(
     top_z_in: float,
 ) -> None:
     for port in preview.projected_side_ports:
-        center_y = PREVIEW_MARGIN + (
-            (top_z_in - port.centerline_height_in) * PREVIEW_SCALE
-        )
         radius_px = port.diameter_in * 0.5 * PREVIEW_SCALE
         for direction in (-1.0, 1.0):
-            center = QPointF(
-                center_x
-                + (
-                    direction
-                    * (preview.outer_radius_in - (port.diameter_in * 0.5))
-                    * PREVIEW_SCALE
+            item = _build_projected_side_port_item(
+                center=_projected_side_port_center(
+                    preview=preview,
+                    center_x=center_x,
+                    top_z_in=top_z_in,
+                    port=port,
+                    direction=direction,
                 ),
-                center_y,
+                radius_px=radius_px,
             )
-            path = QPainterPath()
-            path.addEllipse(center, radius_px, radius_px)
-            item = QGraphicsPathItem(path)
-            pen = QPen(QColor("#6AAED6"))
-            pen.setStyle(Qt.PenStyle.DashLine)
-            item.setPen(pen)
-            item.setBrush(QBrush(Qt.BrushStyle.NoBrush))
             item.setZValue(15.0)
             scene.addItem(item)
+
+
+def _projected_side_port_center(
+    *,
+    preview: CrossSectionPreview,
+    center_x: float,
+    top_z_in: float,
+    port: ProjectedSidePort,
+    direction: float,
+) -> QPointF:
+    """Map one projected side-port marker center into cross-section pixels."""
+    center_y = PREVIEW_MARGIN + ((top_z_in - port.centerline_height_in) * PREVIEW_SCALE)
+    radial_offset_px = (
+        direction * (preview.outer_radius_in - (port.diameter_in * 0.5)) * PREVIEW_SCALE
+    )
+    return QPointF(center_x + radial_offset_px, center_y)
+
+
+def _build_projected_side_port_item(
+    *,
+    center: QPointF,
+    radius_px: float,
+) -> QGraphicsPathItem:
+    """Build the dashed, unfilled ellipse item used for projected side ports."""
+    path = QPainterPath()
+    path.addEllipse(center, radius_px, radius_px)
+    item = QGraphicsPathItem(path)
+    pen = QPen(QColor("#6AAED6"))
+    pen.setStyle(Qt.PenStyle.DashLine)
+    item.setPen(pen)
+    item.setBrush(QBrush(Qt.BrushStyle.NoBrush))
+    return item
 
 
 def render_plan(scene: QGraphicsScene, preview: PlanPreview) -> None:

--- a/tests/test_vessel_drafter_rendering.py
+++ b/tests/test_vessel_drafter_rendering.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from PyQt6.QtCore import Qt
+
+from programmatic_drafting.gui.vessel_drafter_rendering import (
+    PREVIEW_MARGIN,
+    PREVIEW_SCALE,
+    _build_projected_side_port_item,
+    _projected_side_port_center,
+)
+from programmatic_drafting.preview.vessel_drafter_preview import (
+    CrossSectionPreview,
+    ProjectedSidePort,
+)
+
+
+def _preview() -> CrossSectionPreview:
+    return CrossSectionPreview(
+        inner_radius_in=10.0,
+        outer_radius_in=12.0,
+        straight_shell_height_in=20.0,
+        inner_head_depth_in=2.0,
+        outer_head_depth_in=3.0,
+        glass_height_in=8.0,
+        plenum_height_in=12.0,
+        electrode_diameter_in=2.0,
+        bands=(),
+        band_polygons=(),
+        plenum_loop=(),
+        projected_side_ports=(),
+        axial_electrodes=(),
+    )
+
+
+def test_projected_side_port_center_maps_right_edge() -> None:
+    port = ProjectedSidePort(
+        clock_angle_degrees=90.0,
+        centerline_height_in=7.0,
+        diameter_in=2.0,
+    )
+    center = _projected_side_port_center(
+        preview=_preview(),
+        center_x=120.0,
+        top_z_in=23.0,
+        port=port,
+        direction=1.0,
+    )
+
+    assert center.x() == 120.0 + ((12.0 - 1.0) * PREVIEW_SCALE)
+    assert center.y() == PREVIEW_MARGIN + ((23.0 - 7.0) * PREVIEW_SCALE)
+
+
+def test_projected_side_port_item_is_dashed_and_unfilled() -> None:
+    item = _build_projected_side_port_item(
+        center=_projected_side_port_center(
+            preview=_preview(),
+            center_x=120.0,
+            top_z_in=23.0,
+            port=ProjectedSidePort(0.0, 7.0, 2.0),
+            direction=-1.0,
+        ),
+        radius_px=8.0,
+    )
+
+    assert item.pen().style() == Qt.PenStyle.DashLine
+    assert item.brush().style() == Qt.BrushStyle.NoBrush


### PR DESCRIPTION
## Summary
- split projected side-port cross-section rendering into center-mapping and item-construction helpers
- add focused rendering-helper tests for dashed/unfilled side-port markers

## Validation
- `TMPDIR=/tmp PYTHONPATH=src QT_QPA_PLATFORM=offscreen python3 -m pytest tests/test_vessel_drafter_rendering.py -q`
- `python3 -m ruff check src/programmatic_drafting/gui/vessel_drafter_rendering.py tests/test_vessel_drafter_rendering.py`
- `python3 -m black --check src/programmatic_drafting/gui/vessel_drafter_rendering.py tests/test_vessel_drafter_rendering.py`

Refs #26
Refs #32
