### PR TITLE
refactor: split vessel drafter signal wiring

### DIFF
--- a/src/programmatic_drafting/gui/vessel_drafter_window.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_window.py
@@ -183,7 +183,13 @@ class VesselDrafterWindow(QMainWindow):
         return controls_scroll
 
     def _connect_signals(self) -> None:
-        widgets = (
+        self._connect_dimension_signals()
+        self._connect_port_panel_signals()
+        self._connect_preview_signals()
+
+    def _dimension_controls(self) -> tuple:
+        """Return controls whose value changes refresh the 2D previews."""
+        return (
             self.inner_diameter_spin,
             self.glass_depth_spin,
             self.plenum_height_spin,
@@ -197,9 +203,14 @@ class VesselDrafterWindow(QMainWindow):
             self.electrode_insertion_spin,
             self.electrode_extension_spin,
         )
-        for widget in widgets:
+
+    def _connect_dimension_signals(self) -> None:
+        """Connect scalar dimension/electrode controls to preview refresh."""
+        for widget in self._dimension_controls():
             widget.valueChanged.connect(self.update_preview)
 
+    def _connect_port_panel_signals(self) -> None:
+        """Connect port table controls to add/remove/refresh handlers."""
         self.side_port_panel.add_button.clicked.connect(self._prompt_add_side_port)
         self.lid_port_panel.add_button.clicked.connect(self._prompt_add_lid_port)
         self.side_port_panel.remove_button.clicked.connect(
@@ -210,6 +221,9 @@ class VesselDrafterWindow(QMainWindow):
         )
         self.side_port_panel.table.itemChanged.connect(self.update_preview)
         self.lid_port_panel.table.itemChanged.connect(self.update_preview)
+
+    def _connect_preview_signals(self) -> None:
+        """Connect preview option controls to their 3D preview handlers."""
         for checkbox in self.layer_visibility_checkboxes.values():
             checkbox.toggled.connect(self.refresh_three_d_preview)
         self.section_cut_checkbox.toggled.connect(self._handle_section_cut_toggled)

--- a/tests/test_vessel_drafter_gui.py
+++ b/tests/test_vessel_drafter_gui.py
@@ -134,6 +134,7 @@ def test_window_initializes_control_groups() -> None:
     assert window.refresh_button.text() == "Refresh Preview"
     assert window.export_button.text() == "Export STEP"
     assert window.status_label.wordWrap()
+    assert len(window._dimension_controls()) == 12
 
     window.close()
     app.quit()


### PR DESCRIPTION
## Summary
- split vessel drafter signal wiring into dimension, port-panel, and preview-option helper sections
- add a focused assertion for the dimension control seam

## Validation
- `TMPDIR=/tmp PYTHONPATH=src QT_QPA_PLATFORM=offscreen python3 -m pytest tests/test_vessel_drafter_gui.py -q`
- `python3 -m ruff check src/programmatic_drafting/gui/vessel_drafter_window.py tests/test_vessel_drafter_gui.py`
- `python3 -m black --check src/programmatic_drafting/gui/vessel_drafter_window.py tests/test_vessel_drafter_gui.py`

Refs #27
Refs #32
