### PR TITLE
refactor: split vessel drafter status text

### DIFF
--- a/src/programmatic_drafting/gui/vessel_drafter_window.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_window.py
@@ -24,6 +24,7 @@ from PyQt6.QtWidgets import (
 )
 
 from programmatic_drafting.analysis.vessel_drafter_metrics import (
+    MaterialMetricsReport,
     build_material_metrics_report,
 )
 from programmatic_drafting.exporters.step_export import export_vessel_drafter_step
@@ -344,14 +345,7 @@ class VesselDrafterWindow(QMainWindow):
         self.material_summary_table.set_report(metrics)
         self.cross_section_view.sync_to_scene()
         self.plan_view.sync_to_scene()
-        self.status_label.setText(
-            f"Outer diameter: {layout.outer_diameter_in:.2f} in | "
-            f"Full height: {layout.full_height_in:.2f} in | "
-            f"Ports: {len(layout.side_ports)} side, {len(layout.lid_ports)} lid | "
-            f"Refractory: {metrics.refractory_total_volume_ft3:.2f} ft^3, "
-            f"{metrics.refractory_total_surface_area_ft2:.2f} ft^2, "
-            f"{metrics.refractory_total_mass_lb:.1f} lb"
-        )
+        self.status_label.setText(_format_status_text(layout, metrics))
 
     def refresh_three_d_preview(self) -> None:
         if self._suppress_preview_updates:
@@ -596,3 +590,18 @@ def launch() -> int:
     window = VesselDrafterWindow()
     window.show()
     return app.exec()
+
+
+def _format_status_text(
+    layout: VesselDrafterLayout,
+    metrics: MaterialMetricsReport,
+) -> str:
+    """Build the compact status summary shown after preview refresh."""
+    return (
+        f"Outer diameter: {layout.outer_diameter_in:.2f} in | "
+        f"Full height: {layout.full_height_in:.2f} in | "
+        f"Ports: {len(layout.side_ports)} side, {len(layout.lid_ports)} lid | "
+        f"Refractory: {metrics.refractory_total_volume_ft3:.2f} ft^3, "
+        f"{metrics.refractory_total_surface_area_ft2:.2f} ft^2, "
+        f"{metrics.refractory_total_mass_lb:.1f} lb"
+    )

--- a/tests/test_vessel_drafter_gui.py
+++ b/tests/test_vessel_drafter_gui.py
@@ -3,7 +3,11 @@ import os
 import pytest
 from PyQt6.QtWidgets import QApplication
 
-from programmatic_drafting.gui.vessel_drafter_window import VesselDrafterWindow
+from programmatic_drafting.analysis.vessel_drafter_metrics import MaterialMetricsReport
+from programmatic_drafting.gui.vessel_drafter_window import (
+    VesselDrafterWindow,
+    _format_status_text,
+)
 from programmatic_drafting.models.vessel_drafter import VesselLidPort, VesselSidePort
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -157,6 +161,28 @@ def test_section_cut_angle_changes_reset_three_d_view_to_section_plane() -> None
     app.processEvents()
 
     assert window.three_d_canvas.view_state == pytest.approx((0.0, -180.0))
+
+    window.close()
+    app.quit()
+
+
+def test_format_status_text_summarizes_layout_and_metrics() -> None:
+    app = QApplication.instance() or QApplication([])
+    window = VesselDrafterWindow()
+    layout = window.read_layout()
+    metrics = MaterialMetricsReport(
+        component_metrics=(),
+        refractory_total_volume_in3=3456.0,
+        refractory_total_volume_ft3=2.0,
+        refractory_total_surface_area_ft2=3.5,
+        refractory_total_mass_lb=456.7,
+    )
+
+    status = _format_status_text(layout, metrics)
+
+    assert f"Outer diameter: {layout.outer_diameter_in:.2f} in" in status
+    assert "Ports: 0 side, 0 lid" in status
+    assert "Refractory: 2.00 ft^3, 3.50 ft^2, 456.7 lb" in status
 
     window.close()
     app.quit()


### PR DESCRIPTION
## Summary
- split vessel drafter preview status formatting into a focused helper
- add a direct test for status text formatting using layout and material metrics

## Validation
- python3 -m black --check src/programmatic_drafting/gui/vessel_drafter_window.py tests/test_vessel_drafter_gui.py
- TMPDIR=/tmp PYTHONPATH=src QT_QPA_PLATFORM=offscreen python3 -m pytest tests/test_vessel_drafter_gui.py::test_format_status_text_summarizes_layout_and_metrics -q
- python3 -m ruff check src/programmatic_drafting/gui/vessel_drafter_window.py tests/test_vessel_drafter_gui.py

Refs #27, #32
