### PR TITLE
refactor: split vessel scene mesh selection

### DIFF
--- a/src/programmatic_drafting/preview/vessel_drafter_scene.py
+++ b/src/programmatic_drafting/preview/vessel_drafter_scene.py
@@ -64,8 +64,15 @@ def _build_vessel_3d_scene_cached(
     visible_labels = (
         None if visible_label_key_value is None else set(visible_label_key_value)
     )
-    if layout.side_ports or layout.lid_ports:
-        meshes = build_exact_meshes(layout, visible_labels, view_options)
-    else:
-        meshes = build_fast_meshes(layout, visible_labels, view_options)
+    meshes = _build_vessel_3d_scene_meshes(layout, visible_labels, view_options)
     return Vessel3DScene(meshes=meshes, bounds=scene_bounds(meshes))
+
+
+def _build_vessel_3d_scene_meshes(
+    layout: VesselDrafterLayout,
+    visible_labels: set[str] | None,
+    view_options: Vessel3DViewOptions,
+) -> tuple[VesselSceneMesh, ...]:
+    if layout.side_ports or layout.lid_ports:
+        return build_exact_meshes(layout, visible_labels, view_options)
+    return build_fast_meshes(layout, visible_labels, view_options)

--- a/tests/test_vessel_drafter_scene.py
+++ b/tests/test_vessel_drafter_scene.py
@@ -1,0 +1,78 @@
+from programmatic_drafting.models.vessel_drafter import (
+    VesselDrafterLayout,
+    VesselLidPort,
+    VesselSidePort,
+)
+from programmatic_drafting.preview import vessel_drafter_scene as scene_module
+from programmatic_drafting.preview.vessel_drafter_view_options import (
+    Vessel3DViewOptions,
+)
+
+
+def test_scene_mesh_selection_uses_fast_builder_for_plain_layout(
+    monkeypatch,
+) -> None:
+    layout = VesselDrafterLayout()
+    fast_meshes = ("fast",)
+    exact_meshes = ("exact",)
+
+    monkeypatch.setattr(
+        scene_module,
+        "build_fast_meshes",
+        lambda *args: fast_meshes,
+    )
+    monkeypatch.setattr(
+        scene_module,
+        "build_exact_meshes",
+        lambda *args: exact_meshes,
+    )
+
+    result = scene_module._build_vessel_3d_scene_meshes(
+        layout,
+        None,
+        Vessel3DViewOptions(),
+    )
+
+    assert result == fast_meshes
+
+
+def test_scene_mesh_selection_uses_exact_builder_when_ports_exist(
+    monkeypatch,
+) -> None:
+    layout = VesselDrafterLayout(
+        side_ports=(
+            VesselSidePort(
+                clock_angle_degrees=30.0,
+                diameter_in=3.0,
+                height_above_glass_surface_in=6.0,
+            ),
+        ),
+        lid_ports=(
+            VesselLidPort(
+                clock_angle_degrees=225.0,
+                diameter_in=4.0,
+                radial_distance_from_center_in=8.0,
+            ),
+        ),
+    )
+    fast_meshes = ("fast",)
+    exact_meshes = ("exact",)
+
+    monkeypatch.setattr(
+        scene_module,
+        "build_fast_meshes",
+        lambda *args: fast_meshes,
+    )
+    monkeypatch.setattr(
+        scene_module,
+        "build_exact_meshes",
+        lambda *args: exact_meshes,
+    )
+
+    result = scene_module._build_vessel_3d_scene_meshes(
+        layout,
+        {"side_ports"},
+        Vessel3DViewOptions(),
+    )
+
+    assert result == exact_meshes


### PR DESCRIPTION
## Summary
- extract vessel 3D scene mesh-selection logic into a helper
- add coverage for the fast mesh path and exact side/lid-port mesh path

## Validation
- python3 -m black --check src/programmatic_drafting/preview/vessel_drafter_scene.py tests/test_vessel_drafter_scene.py
- TMPDIR=/tmp PYTHONPATH=src QT_QPA_PLATFORM=offscreen python3 -m pytest tests/test_vessel_drafter_scene.py -q
- python3 -m ruff check src/programmatic_drafting/preview/vessel_drafter_scene.py tests/test_vessel_drafter_scene.py

Refs #21, #27, #32
