### PR TITLE
refactor: centralize vessel manifest assembly

### DIFF
--- a/src/programmatic_drafting/models/vessel_drafter.py
+++ b/src/programmatic_drafting/models/vessel_drafter.py
@@ -32,6 +32,7 @@ from programmatic_drafting.models.vessel_drafter_manifest import (
     _build_shell_materials_manifest,
     _build_side_port_manifest,
     _build_vessel_manifest,
+    build_vessel_drafter_manifest,
 )
 from programmatic_drafting.models.vessel_drafter_types import (
     MaterialLayer,
@@ -62,6 +63,7 @@ __all__ = [
     "_build_shell_materials_manifest",
     "_build_side_port_manifest",
     "_build_vessel_manifest",
+    "build_vessel_drafter_manifest",
 ]
 
 
@@ -277,18 +279,7 @@ class VesselDrafterLayout:
             )
 
     def to_manifest(self) -> dict[str, Any]:
-        return {
-            "project": "vessel_drafter_default",
-            "units": {"source": "inches", "cad": "millimeters"},
-            "vessel": _build_vessel_manifest(self),
-            "materials": _build_shell_materials_manifest(self.layers[1:]),
-            "glass_bath": _build_glass_bath_manifest(
-                self.layers[0], self.glass_depth_in
-            ),
-            "electrodes": _build_electrodes_manifest(self),
-            "ports": _build_ports_manifest(self),
-            "drafting_assumptions": _build_drafting_assumptions_manifest(),
-        }
+        return build_vessel_drafter_manifest(self)
 
 
 DEFAULT_VESSEL_DRAFTER_LAYOUT = VesselDrafterLayout()

--- a/src/programmatic_drafting/models/vessel_drafter_manifest.py
+++ b/src/programmatic_drafting/models/vessel_drafter_manifest.py
@@ -20,6 +20,25 @@ if TYPE_CHECKING:
     from programmatic_drafting.models.vessel_drafter import VesselDrafterLayout
 
 
+def build_vessel_drafter_manifest(
+    layout: VesselDrafterLayout,
+) -> dict[str, Any]:
+    """Build the full vessel drafter manifest."""
+    return {
+        "project": "vessel_drafter_default",
+        "units": {"source": "inches", "cad": "millimeters"},
+        "vessel": _build_vessel_manifest(layout),
+        "materials": _build_shell_materials_manifest(layout.layers[1:]),
+        "glass_bath": _build_glass_bath_manifest(
+            layout.layers[0],
+            layout.glass_depth_in,
+        ),
+        "electrodes": _build_electrodes_manifest(layout),
+        "ports": _build_ports_manifest(layout),
+        "drafting_assumptions": _build_drafting_assumptions_manifest(),
+    }
+
+
 def _build_vessel_manifest(layout: VesselDrafterLayout) -> dict[str, Any]:
     """Build the vessel geometry section for a manifest.
 

--- a/tests/test_vessel_drafter_manifest.py
+++ b/tests/test_vessel_drafter_manifest.py
@@ -12,6 +12,7 @@ from programmatic_drafting.models.vessel_drafter import (
     _build_shell_materials_manifest,
     _build_side_port_manifest,
     _build_vessel_manifest,
+    build_vessel_drafter_manifest,
 )
 
 
@@ -49,6 +50,25 @@ def test_build_glass_bath_manifest_uses_glass_layer_properties() -> None:
     assert manifest["display_name"] == "Glass Bath"
     assert manifest["height_in"] == 14.0
     assert manifest["color_hex"] == layer.color_hex
+
+
+def test_build_vessel_drafter_manifest_includes_all_sections() -> None:
+    manifest = build_vessel_drafter_manifest(DEFAULT_VESSEL_DRAFTER_LAYOUT)
+
+    assert manifest["project"] == "vessel_drafter_default"
+    assert manifest["units"] == {"source": "inches", "cad": "millimeters"}
+    assert manifest["vessel"]["outer_head_depth_in"] == 24.5
+    assert manifest["materials"]["steel_shell"]["thickness_in"] == 0.5
+    assert manifest["glass_bath"]["display_name"] == "Glass Bath"
+    assert manifest["electrodes"]["modeled_length_in"] == 50.0
+    assert manifest["ports"] == {"side": [], "lid": []}
+    assert manifest["drafting_assumptions"]["axis_convention"] == "Z up"
+
+
+def test_layout_to_manifest_delegates_to_manifest_helper() -> None:
+    manifest = DEFAULT_VESSEL_DRAFTER_LAYOUT.to_manifest()
+
+    assert manifest == build_vessel_drafter_manifest(DEFAULT_VESSEL_DRAFTER_LAYOUT)
 
 
 def test_build_port_manifest_helpers_track_layout_geometry() -> None:


### PR DESCRIPTION
## Summary
- move full vessel manifest assembly into the manifest helper module
- keep VesselDrafterLayout.to_manifest() as a thin delegator
- add direct coverage for full manifest assembly and delegation

## Validation
- PYTHONPATH=src python3 -m pytest -s tests/test_vessel_drafter_manifest.py tests/test_vessel_drafter_defaults.py tests/test_vessel_drafter_geometry.py
- python3 -m ruff check src/programmatic_drafting/models/vessel_drafter.py src/programmatic_drafting/models/vessel_drafter_manifest.py tests/test_vessel_drafter_manifest.py
- python3 -m black --check src/programmatic_drafting/models/vessel_drafter.py src/programmatic_drafting/models/vessel_drafter_manifest.py tests/test_vessel_drafter_manifest.py

Refs #27, #32
