### PR TITLE
refactor(#27): split vessel_drafter_window into focused UI components

### DIFF
--- a/src/programmatic_drafting/gui/vessel_drafter_port_prompts.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_port_prompts.py
@@ -1,0 +1,58 @@
+"""Modal dialog helpers for adding vessel side and lid ports.
+
+These factories wrap :class:`PortValueDialog` with the field specifications
+used by the main window. They return ``None`` if the user cancels the dialog
+so callers can branch cleanly without worrying about Qt's ``QDialog.exec``
+return codes.
+"""
+
+from __future__ import annotations
+
+from PyQt6.QtWidgets import QWidget
+
+from programmatic_drafting.gui.vessel_drafter_port_panel import (
+    PortFieldSpec,
+    PortValueDialog,
+)
+from programmatic_drafting.models.vessel_drafter import (
+    VesselLidPort,
+    VesselSidePort,
+)
+
+_SIDE_PORT_FIELDS: tuple[PortFieldSpec, ...] = (
+    PortFieldSpec("Clock angle (deg)", 0.0, 0.0, 360.0),
+    PortFieldSpec("Diameter (in)", 3.0, 0.1, 100.0),
+    PortFieldSpec("Height above glass (in)", 4.0, 0.0, 250.0),
+)
+
+_LID_PORT_FIELDS: tuple[PortFieldSpec, ...] = (
+    PortFieldSpec("Clock angle (deg)", 0.0, 0.0, 360.0),
+    PortFieldSpec("Diameter (in)", 4.0, 0.1, 100.0),
+    PortFieldSpec("Distance from center (in)", 8.0, 0.0, 500.0),
+)
+
+
+def prompt_add_side_port(parent: QWidget) -> VesselSidePort | None:
+    """Run the add-side-port dialog and return the chosen port, or ``None``."""
+    dialog = PortValueDialog("Add Side Port", _SIDE_PORT_FIELDS, parent)
+    if not dialog.exec():
+        return None
+    angle, diameter, height = dialog.values()
+    return VesselSidePort(
+        clock_angle_degrees=angle,
+        diameter_in=diameter,
+        height_above_glass_surface_in=height,
+    )
+
+
+def prompt_add_lid_port(parent: QWidget) -> VesselLidPort | None:
+    """Run the add-lid-port dialog and return the chosen port, or ``None``."""
+    dialog = PortValueDialog("Add Lid Port", _LID_PORT_FIELDS, parent)
+    if not dialog.exec():
+        return None
+    angle, diameter, radius = dialog.values()
+    return VesselLidPort(
+        clock_angle_degrees=angle,
+        diameter_in=diameter,
+        radial_distance_from_center_in=radius,
+    )

--- a/src/programmatic_drafting/gui/vessel_drafter_preview_panel.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_preview_panel.py
@@ -1,0 +1,66 @@
+"""Reusable zoomable 2D preview panel for the vessel drafter GUI.
+
+The panel wraps a :class:`ZoomableGraphicsView` with a titled header row of
+zoom-in / zoom-out / reset buttons. It is intentionally free of vessel-drafter
+specific logic so the window can compose one panel per 2D preview (cross-section
+and plan view).
+"""
+
+from __future__ import annotations
+
+from PyQt6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from programmatic_drafting.gui.zoomable_graphics_view import ZoomableGraphicsView
+
+
+class PreviewPanel(QWidget):
+    """Titled zoomable 2D preview panel.
+
+    Parameters
+    ----------
+    title:
+        Human-readable label shown in the header row.
+    view:
+        The :class:`ZoomableGraphicsView` to host inside the panel. The caller
+        remains responsible for attaching a :class:`QGraphicsScene` to the view.
+    parent:
+        Optional Qt parent widget.
+    """
+
+    def __init__(
+        self,
+        title: str,
+        view: ZoomableGraphicsView,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._view = view
+        self._title_label = QLabel(title)
+        self._zoom_in_button = QPushButton("+")
+        self._zoom_in_button.clicked.connect(view.zoom_in)
+        self._zoom_out_button = QPushButton("-")
+        self._zoom_out_button.clicked.connect(view.zoom_out)
+        self._reset_button = QPushButton("Reset")
+        self._reset_button.clicked.connect(view.reset_zoom)
+
+        header_layout = QHBoxLayout()
+        header_layout.addWidget(self._title_label)
+        header_layout.addStretch(1)
+        header_layout.addWidget(self._zoom_out_button)
+        header_layout.addWidget(self._zoom_in_button)
+        header_layout.addWidget(self._reset_button)
+
+        panel_layout = QVBoxLayout(self)
+        panel_layout.addLayout(header_layout)
+        panel_layout.addWidget(view, 1)
+
+    @property
+    def view(self) -> ZoomableGraphicsView:
+        """Return the hosted zoomable graphics view."""
+        return self._view

--- a/src/programmatic_drafting/gui/vessel_drafter_three_d_sidebar.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_three_d_sidebar.py
@@ -1,0 +1,118 @@
+"""3D-preview sidebar widget for the vessel drafter GUI.
+
+The sidebar bundles the layer-visibility checkboxes, section-cut controls,
+the reset-view button, and the material summary table that sit alongside the
+3D canvas. It exposes its constituent widgets as public attributes so the
+main window can wire signals and read state without reaching into private
+state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from programmatic_drafting.gui.material_summary_table import MaterialSummaryTable
+from programmatic_drafting.gui.vessel_drafter_port_panel import make_double_spin
+from programmatic_drafting.models.vessel_drafter import (
+    DEFAULT_VESSEL_DRAFTER_LAYOUT,
+)
+from programmatic_drafting.preview.vessel_drafter_view_options import (
+    Vessel3DViewOptions,
+)
+
+_LAYER_LABELS: tuple[str, ...] = (
+    "glass_bath",
+    "hot_face_refractory",
+    "ifb",
+    "duraboard",
+    "steel_shell",
+    "electrodes",
+)
+
+
+def _build_layer_visibility_checkboxes(
+    labels: Iterable[str] = _LAYER_LABELS,
+) -> dict[str, QCheckBox]:
+    """Build the per-material visibility checkboxes keyed by layer label."""
+    materials = DEFAULT_VESSEL_DRAFTER_LAYOUT.material_properties_by_name
+    checkboxes: dict[str, QCheckBox] = {}
+    for label in labels:
+        checkbox = QCheckBox(materials[label].display_name)
+        checkbox.setChecked(True)
+        checkboxes[label] = checkbox
+    return checkboxes
+
+
+def _build_section_cut_angle_spin() -> QDoubleSpinBox:
+    """Build the disabled-by-default section-cut angle spinner."""
+    spin = make_double_spin(0.0, 0.0, 360.0)
+    spin.setSingleStep(15.0)
+    spin.setEnabled(False)
+    return spin
+
+
+class VesselThreeDSidebar(QWidget):
+    """Sidebar that groups 3D-preview controls next to the canvas."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.reset_view_button = QPushButton("Reset 3D View")
+        self.layer_visibility_checkboxes = _build_layer_visibility_checkboxes()
+        self.section_cut_checkbox = QCheckBox("Split on vertical plane")
+        self.section_cut_angle_spin = _build_section_cut_angle_spin()
+        self.material_summary_table = MaterialSummaryTable(self)
+
+        layout = QVBoxLayout(self)
+        instructions = QLabel(
+            "Drag to rotate the model. Use the checkboxes to hide layers."
+        )
+        instructions.setWordWrap(True)
+        layout.addWidget(instructions)
+        layout.addWidget(self.reset_view_button)
+        layout.addWidget(self._build_layer_visibility_panel())
+        layout.addWidget(self._build_section_cut_panel())
+        layout.addWidget(QLabel("Material Summary"))
+        layout.addWidget(self.material_summary_table)
+        layout.addStretch(1)
+        self.setMinimumWidth(360)
+
+    def _build_layer_visibility_panel(self) -> QWidget:
+        panel = QWidget()
+        panel_layout = QVBoxLayout(panel)
+        panel_layout.addWidget(QLabel("Visible Layers"))
+        for checkbox in self.layer_visibility_checkboxes.values():
+            panel_layout.addWidget(checkbox)
+        panel_layout.addStretch(1)
+        return panel
+
+    def _build_section_cut_panel(self) -> QWidget:
+        panel = QWidget()
+        panel_layout = QFormLayout(panel)
+        panel_layout.addRow(self.section_cut_checkbox)
+        panel_layout.addRow("Split angle (deg)", self.section_cut_angle_spin)
+        return panel
+
+    def visible_layer_labels(self) -> set[str]:
+        """Return the set of layer labels currently marked visible."""
+        return {
+            label
+            for label, checkbox in self.layer_visibility_checkboxes.items()
+            if checkbox.isChecked()
+        }
+
+    def read_view_options(self) -> Vessel3DViewOptions:
+        """Return the current 3D view-option values from the sidebar controls."""
+        return Vessel3DViewOptions(
+            split_enabled=self.section_cut_checkbox.isChecked(),
+            split_angle_degrees=self.section_cut_angle_spin.value(),
+        )

--- a/src/programmatic_drafting/gui/vessel_drafter_window.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_window.py
@@ -7,8 +7,6 @@ from pathlib import Path
 
 from PyQt6.QtWidgets import (
     QApplication,
-    QCheckBox,
-    QDoubleSpinBox,
     QFileDialog,
     QFormLayout,
     QGraphicsScene,
@@ -28,19 +26,24 @@ from programmatic_drafting.analysis.vessel_drafter_metrics import (
     build_material_metrics_report,
 )
 from programmatic_drafting.exporters.step_export import export_vessel_drafter_step
-from programmatic_drafting.gui.material_summary_table import MaterialSummaryTable
 from programmatic_drafting.gui.vessel_drafter_port_panel import (
-    PortFieldSpec,
     PortTableSection,
-    PortValueDialog,
     make_double_spin,
 )
+from programmatic_drafting.gui.vessel_drafter_port_prompts import (
+    prompt_add_lid_port,
+    prompt_add_side_port,
+)
+from programmatic_drafting.gui.vessel_drafter_preview_panel import PreviewPanel
 from programmatic_drafting.gui.vessel_drafter_rendering import (
     render_cross_section,
     render_plan,
 )
 from programmatic_drafting.gui.vessel_drafter_three_d_canvas import (
     VesselDrafterThreeDCanvas,
+)
+from programmatic_drafting.gui.vessel_drafter_three_d_sidebar import (
+    VesselThreeDSidebar,
 )
 from programmatic_drafting.gui.zoomable_graphics_view import ZoomableGraphicsView
 from programmatic_drafting.models.vessel_drafter import (
@@ -54,9 +57,6 @@ from programmatic_drafting.preview.vessel_drafter_preview import (
     build_plan_preview,
 )
 from programmatic_drafting.preview.vessel_drafter_scene import build_vessel_3d_scene
-from programmatic_drafting.preview.vessel_drafter_view_options import (
-    Vessel3DViewOptions,
-)
 
 
 class VesselDrafterWindow(QMainWindow):
@@ -111,7 +111,7 @@ class VesselDrafterWindow(QMainWindow):
         )
 
     def _build_preview_widgets(self) -> None:
-        """Create preview scenes, views, controls, and status widgets."""
+        """Create preview scenes, views, canvas, and sidebar widgets."""
         self.cross_section_scene = QGraphicsScene(self)
         self.cross_section_view = ZoomableGraphicsView(self)
         self.cross_section_view.setScene(self.cross_section_scene)
@@ -120,10 +120,15 @@ class VesselDrafterWindow(QMainWindow):
         self.plan_view.setScene(self.plan_scene)
         self.preview_tabs = QTabWidget(self)
         self.three_d_canvas = VesselDrafterThreeDCanvas()
-        self.material_summary_table = MaterialSummaryTable(self)
-        self.layer_visibility_checkboxes = self._build_layer_visibility_checkboxes()
-        self.section_cut_checkbox = QCheckBox("Split on vertical plane")
-        self.section_cut_angle_spin = self._build_section_cut_angle_spin()
+        self.three_d_sidebar = VesselThreeDSidebar()
+        # Expose sidebar sub-widgets for backward compatibility with callers
+        # and tests that reach them through the window.
+        self.layer_visibility_checkboxes = (
+            self.three_d_sidebar.layer_visibility_checkboxes
+        )
+        self.section_cut_checkbox = self.three_d_sidebar.section_cut_checkbox
+        self.section_cut_angle_spin = self.three_d_sidebar.section_cut_angle_spin
+        self.material_summary_table = self.three_d_sidebar.material_summary_table
         self.status_label = QLabel()
         self.status_label.setWordWrap(True)
 
@@ -232,6 +237,9 @@ class VesselDrafterWindow(QMainWindow):
             self._handle_section_cut_angle_changed
         )
         self.preview_tabs.currentChanged.connect(self._handle_preview_tab_changed)
+        self.three_d_sidebar.reset_view_button.clicked.connect(
+            self.three_d_canvas.reset_view
+        )
 
     def write_layout(self, layout: VesselDrafterLayout) -> None:
         self._suppress_preview_updates = True
@@ -387,44 +395,14 @@ class VesselDrafterWindow(QMainWindow):
         self.status_label.setText(f"Exported {output_path}")
 
     def _prompt_add_side_port(self) -> None:
-        dialog = PortValueDialog(
-            "Add Side Port",
-            (
-                PortFieldSpec("Clock angle (deg)", 0.0, 0.0, 360.0),
-                PortFieldSpec("Diameter (in)", 3.0, 0.1, 100.0),
-                PortFieldSpec("Height above glass (in)", 4.0, 0.0, 250.0),
-            ),
-            self,
-        )
-        if dialog.exec():
-            angle, diameter, height = dialog.values()
-            self.add_side_port(
-                VesselSidePort(
-                    clock_angle_degrees=angle,
-                    diameter_in=diameter,
-                    height_above_glass_surface_in=height,
-                )
-            )
+        port = prompt_add_side_port(self)
+        if port is not None:
+            self.add_side_port(port)
 
     def _prompt_add_lid_port(self) -> None:
-        dialog = PortValueDialog(
-            "Add Lid Port",
-            (
-                PortFieldSpec("Clock angle (deg)", 0.0, 0.0, 360.0),
-                PortFieldSpec("Diameter (in)", 4.0, 0.1, 100.0),
-                PortFieldSpec("Distance from center (in)", 8.0, 0.0, 500.0),
-            ),
-            self,
-        )
-        if dialog.exec():
-            angle, diameter, radius = dialog.values()
-            self.add_lid_port(
-                VesselLidPort(
-                    clock_angle_degrees=angle,
-                    diameter_in=diameter,
-                    radial_distance_from_center_in=radius,
-                )
-            )
+        port = prompt_add_lid_port(self)
+        if port is not None:
+            self.add_lid_port(port)
 
     def _remove_selected_side_ports(self) -> None:
         self.side_port_panel.remove_selected_rows()
@@ -434,136 +412,38 @@ class VesselDrafterWindow(QMainWindow):
         self.lid_port_panel.remove_selected_rows()
         self.update_preview()
 
-    def _build_preview_panel(
-        self,
-        title: str,
-        view: ZoomableGraphicsView,
-    ) -> QWidget:
-        title_label = QLabel(title)
-        zoom_in_button = QPushButton("+")
-        zoom_in_button.clicked.connect(view.zoom_in)
-        zoom_out_button = QPushButton("-")
-        zoom_out_button.clicked.connect(view.zoom_out)
-        reset_button = QPushButton("Reset")
-        reset_button.clicked.connect(view.reset_zoom)
-
-        header_layout = QHBoxLayout()
-        header_layout.addWidget(title_label)
-        header_layout.addStretch(1)
-        header_layout.addWidget(zoom_out_button)
-        header_layout.addWidget(zoom_in_button)
-        header_layout.addWidget(reset_button)
-
-        panel = QWidget()
-        panel_layout = QVBoxLayout(panel)
-        panel_layout.addLayout(header_layout)
-        panel_layout.addWidget(view, 1)
-        return panel
-
     def _build_preview_tabs(self) -> QTabWidget:
         previews_tab = QWidget()
         previews_layout = QVBoxLayout(previews_tab)
         previews_layout.addWidget(
-            self._build_preview_panel("Cross-Section Preview", self.cross_section_view),
+            PreviewPanel("Cross-Section Preview", self.cross_section_view),
             1,
         )
         previews_layout.addWidget(
-            self._build_preview_panel("Top View Preview", self.plan_view),
+            PreviewPanel("Top View Preview", self.plan_view),
             1,
         )
 
         three_d_tab = QWidget()
         three_d_layout = QHBoxLayout(three_d_tab)
         three_d_layout.addWidget(self.three_d_canvas, 1)
-        three_d_layout.addWidget(self._build_three_d_sidebar(), 0)
+        three_d_layout.addWidget(self.three_d_sidebar, 0)
 
         self.preview_tabs.addTab(previews_tab, "2D Previews")
         self.preview_tabs.addTab(three_d_tab, "3D Preview")
         return self.preview_tabs
 
-    def _build_three_d_sidebar(self) -> QWidget:
-        panel = QWidget()
-        layout = QVBoxLayout(panel)
-        instructions = QLabel(
-            "Drag to rotate the model. Use the checkboxes to hide layers."
-        )
-        instructions.setWordWrap(True)
-        reset_view_button = QPushButton("Reset 3D View")
-        reset_view_button.clicked.connect(self.three_d_canvas.reset_view)
-
-        layout.addWidget(instructions)
-        layout.addWidget(reset_view_button)
-        layout.addWidget(self._build_layer_visibility_panel())
-        layout.addWidget(self._build_section_cut_panel())
-        layout.addWidget(QLabel("Material Summary"))
-        layout.addWidget(self.material_summary_table)
-        layout.addStretch(1)
-        panel.setMinimumWidth(360)
-        return panel
-
-    def _build_layer_visibility_panel(self) -> QWidget:
-        panel = QWidget()
-        layout = QVBoxLayout(panel)
-        layout.addWidget(QLabel("Visible Layers"))
-        for checkbox in self.layer_visibility_checkboxes.values():
-            layout.addWidget(checkbox)
-        layout.addStretch(1)
-        return panel
-
-    def _build_section_cut_panel(self) -> QWidget:
-        panel = QWidget()
-        layout = QFormLayout(panel)
-        layout.addRow(self.section_cut_checkbox)
-        layout.addRow("Split angle (deg)", self.section_cut_angle_spin)
-        return panel
-
-    def _build_layer_visibility_checkboxes(self) -> dict[str, QCheckBox]:
-        materials = DEFAULT_VESSEL_DRAFTER_LAYOUT.material_properties_by_name
-        labels = (
-            "glass_bath",
-            "hot_face_refractory",
-            "ifb",
-            "duraboard",
-            "steel_shell",
-            "electrodes",
-        )
-        checkboxes: dict[str, QCheckBox] = {}
-        for label in labels:
-            checkbox = QCheckBox(materials[label].display_name)
-            checkbox.setChecked(True)
-            checkboxes[label] = checkbox
-        return checkboxes
-
-    def _build_section_cut_angle_spin(self) -> QDoubleSpinBox:
-        spin = make_double_spin(0.0, 0.0, 360.0)
-        spin.setSingleStep(15.0)
-        spin.setEnabled(False)
-        return spin
-
     def _update_three_d_preview(self, layout: VesselDrafterLayout) -> None:
-        view_options = self._read_three_d_view_options()
+        view_options = self.three_d_sidebar.read_view_options()
         self.three_d_canvas.draw_scene(
             build_vessel_3d_scene(
                 layout,
-                visible_labels=self._visible_layer_labels(),
+                visible_labels=self.three_d_sidebar.visible_layer_labels(),
                 view_options=view_options,
             ),
             view_options,
         )
         self._three_d_preview_dirty = False
-
-    def _visible_layer_labels(self) -> set[str]:
-        return {
-            label
-            for label, checkbox in self.layer_visibility_checkboxes.items()
-            if checkbox.isChecked()
-        }
-
-    def _read_three_d_view_options(self) -> Vessel3DViewOptions:
-        return Vessel3DViewOptions(
-            split_enabled=self.section_cut_checkbox.isChecked(),
-            split_angle_degrees=self.section_cut_angle_spin.value(),
-        )
 
     def _handle_preview_tab_changed(self, index: int) -> None:
         if index != self.preview_tabs.indexOf(self.preview_tabs.widget(1)):
@@ -576,12 +456,14 @@ class VesselDrafterWindow(QMainWindow):
 
     def _handle_section_cut_toggled(self, checked: bool) -> None:
         self.section_cut_angle_spin.setEnabled(checked)
-        self.three_d_canvas.queue_default_view(self._read_three_d_view_options())
+        self.three_d_canvas.queue_default_view(self.three_d_sidebar.read_view_options())
         self.refresh_three_d_preview()
 
     def _handle_section_cut_angle_changed(self, _: float) -> None:
         if self.section_cut_checkbox.isChecked():
-            self.three_d_canvas.queue_default_view(self._read_three_d_view_options())
+            self.three_d_canvas.queue_default_view(
+                self.three_d_sidebar.read_view_options()
+            )
         self.refresh_three_d_preview()
 
 

--- a/tests/test_vessel_drafter_port_prompts.py
+++ b/tests/test_vessel_drafter_port_prompts.py
@@ -1,6 +1,7 @@
 """Tests for the side/lid port prompt dialog helpers."""
 
 import os
+from typing import cast
 
 import pytest
 from PyQt6.QtWidgets import QApplication, QWidget
@@ -19,7 +20,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 
 def _ensure_app() -> QApplication:
-    return QApplication.instance() or QApplication([])
+    return cast(QApplication, QApplication.instance() or QApplication([]))
 
 
 class _FakeDialog:

--- a/tests/test_vessel_drafter_port_prompts.py
+++ b/tests/test_vessel_drafter_port_prompts.py
@@ -1,0 +1,115 @@
+"""Tests for the side/lid port prompt dialog helpers."""
+
+import os
+
+import pytest
+from PyQt6.QtWidgets import QApplication, QWidget
+
+from programmatic_drafting.gui import vessel_drafter_port_prompts
+from programmatic_drafting.gui.vessel_drafter_port_prompts import (
+    prompt_add_lid_port,
+    prompt_add_side_port,
+)
+from programmatic_drafting.models.vessel_drafter import (
+    VesselLidPort,
+    VesselSidePort,
+)
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+def _ensure_app() -> QApplication:
+    return QApplication.instance() or QApplication([])
+
+
+class _FakeDialog:
+    """Stand-in for ``PortValueDialog`` that bypasses Qt's modal exec loop."""
+
+    def __init__(self, accept: bool, values: tuple[float, float, float]) -> None:
+        self._accept = accept
+        self._values = values
+
+    def __call__(self, *_args: object, **_kwargs: object) -> "_FakeDialog":
+        return self
+
+    def exec(self) -> int:
+        return 1 if self._accept else 0
+
+    def values(self) -> tuple[float, float, float]:
+        return self._values
+
+
+def test_prompt_add_side_port_returns_none_when_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _ensure_app()
+    parent = QWidget()
+    try:
+        monkeypatch.setattr(
+            vessel_drafter_port_prompts,
+            "PortValueDialog",
+            _FakeDialog(accept=False, values=(0.0, 0.0, 0.0)),
+        )
+        assert prompt_add_side_port(parent) is None
+    finally:
+        parent.deleteLater()
+        app.processEvents()
+
+
+def test_prompt_add_side_port_returns_port_when_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _ensure_app()
+    parent = QWidget()
+    try:
+        monkeypatch.setattr(
+            vessel_drafter_port_prompts,
+            "PortValueDialog",
+            _FakeDialog(accept=True, values=(45.0, 2.5, 7.0)),
+        )
+        port = prompt_add_side_port(parent)
+        assert isinstance(port, VesselSidePort)
+        assert port.clock_angle_degrees == pytest.approx(45.0)
+        assert port.diameter_in == pytest.approx(2.5)
+        assert port.height_above_glass_surface_in == pytest.approx(7.0)
+    finally:
+        parent.deleteLater()
+        app.processEvents()
+
+
+def test_prompt_add_lid_port_returns_port_when_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _ensure_app()
+    parent = QWidget()
+    try:
+        monkeypatch.setattr(
+            vessel_drafter_port_prompts,
+            "PortValueDialog",
+            _FakeDialog(accept=True, values=(90.0, 3.0, 8.5)),
+        )
+        port = prompt_add_lid_port(parent)
+        assert isinstance(port, VesselLidPort)
+        assert port.clock_angle_degrees == pytest.approx(90.0)
+        assert port.diameter_in == pytest.approx(3.0)
+        assert port.radial_distance_from_center_in == pytest.approx(8.5)
+    finally:
+        parent.deleteLater()
+        app.processEvents()
+
+
+def test_prompt_add_lid_port_returns_none_when_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _ensure_app()
+    parent = QWidget()
+    try:
+        monkeypatch.setattr(
+            vessel_drafter_port_prompts,
+            "PortValueDialog",
+            _FakeDialog(accept=False, values=(0.0, 0.0, 0.0)),
+        )
+        assert prompt_add_lid_port(parent) is None
+    finally:
+        parent.deleteLater()
+        app.processEvents()

--- a/tests/test_vessel_drafter_preview_panel.py
+++ b/tests/test_vessel_drafter_preview_panel.py
@@ -1,6 +1,7 @@
 """Tests for the reusable zoomable preview-panel widget."""
 
 import os
+from typing import cast
 
 import pytest
 from PyQt6.QtWidgets import QApplication
@@ -12,7 +13,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 
 def _ensure_app() -> QApplication:
-    return QApplication.instance() or QApplication([])
+    return cast(QApplication, QApplication.instance() or QApplication([]))
 
 
 def test_preview_panel_hosts_provided_view() -> None:

--- a/tests/test_vessel_drafter_preview_panel.py
+++ b/tests/test_vessel_drafter_preview_panel.py
@@ -1,0 +1,47 @@
+"""Tests for the reusable zoomable preview-panel widget."""
+
+import os
+
+import pytest
+from PyQt6.QtWidgets import QApplication
+
+from programmatic_drafting.gui.vessel_drafter_preview_panel import PreviewPanel
+from programmatic_drafting.gui.zoomable_graphics_view import ZoomableGraphicsView
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+def _ensure_app() -> QApplication:
+    return QApplication.instance() or QApplication([])
+
+
+def test_preview_panel_hosts_provided_view() -> None:
+    app = _ensure_app()
+    view = ZoomableGraphicsView()
+    panel = PreviewPanel("Cross-Section Preview", view)
+    try:
+        assert panel.view is view
+    finally:
+        panel.deleteLater()
+        app.processEvents()
+
+
+def test_preview_panel_zoom_buttons_invoke_view_zoom_controls() -> None:
+    app = _ensure_app()
+    view = ZoomableGraphicsView()
+    panel = PreviewPanel("Top View Preview", view)
+    try:
+        assert view.zoom_factor == pytest.approx(1.0)
+
+        panel._zoom_in_button.click()
+        assert view.zoom_factor > 1.0
+
+        panel._zoom_out_button.click()
+        panel._zoom_out_button.click()
+        assert view.zoom_factor < 1.0
+
+        panel._reset_button.click()
+        assert view.zoom_factor == pytest.approx(1.0)
+    finally:
+        panel.deleteLater()
+        app.processEvents()

--- a/tests/test_vessel_drafter_three_d_sidebar.py
+++ b/tests/test_vessel_drafter_three_d_sidebar.py
@@ -1,0 +1,80 @@
+"""Tests for the 3D-preview sidebar widget extracted from the window module."""
+
+import os
+
+import pytest
+from PyQt6.QtWidgets import QApplication
+
+from programmatic_drafting.gui.vessel_drafter_three_d_sidebar import (
+    VesselThreeDSidebar,
+)
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+def _ensure_app() -> QApplication:
+    return QApplication.instance() or QApplication([])
+
+
+def test_sidebar_exposes_expected_layer_checkboxes() -> None:
+    app = _ensure_app()
+    sidebar = VesselThreeDSidebar()
+    try:
+        labels = set(sidebar.layer_visibility_checkboxes)
+        assert labels == {
+            "glass_bath",
+            "hot_face_refractory",
+            "ifb",
+            "duraboard",
+            "steel_shell",
+            "electrodes",
+        }
+        assert all(
+            checkbox.isChecked()
+            for checkbox in sidebar.layer_visibility_checkboxes.values()
+        )
+    finally:
+        sidebar.deleteLater()
+        app.processEvents()
+
+
+def test_sidebar_visible_layer_labels_tracks_checkbox_state() -> None:
+    app = _ensure_app()
+    sidebar = VesselThreeDSidebar()
+    try:
+        assert "steel_shell" in sidebar.visible_layer_labels()
+        sidebar.layer_visibility_checkboxes["steel_shell"].setChecked(False)
+        assert "steel_shell" not in sidebar.visible_layer_labels()
+    finally:
+        sidebar.deleteLater()
+        app.processEvents()
+
+
+def test_sidebar_section_cut_defaults_disable_angle_spin() -> None:
+    app = _ensure_app()
+    sidebar = VesselThreeDSidebar()
+    try:
+        assert not sidebar.section_cut_checkbox.isChecked()
+        assert not sidebar.section_cut_angle_spin.isEnabled()
+        assert sidebar.section_cut_angle_spin.maximum() == pytest.approx(360.0)
+    finally:
+        sidebar.deleteLater()
+        app.processEvents()
+
+
+def test_sidebar_read_view_options_reflects_controls() -> None:
+    app = _ensure_app()
+    sidebar = VesselThreeDSidebar()
+    try:
+        options = sidebar.read_view_options()
+        assert options.split_enabled is False
+        assert options.split_angle_degrees == pytest.approx(0.0)
+
+        sidebar.section_cut_checkbox.setChecked(True)
+        sidebar.section_cut_angle_spin.setValue(90.0)
+        options = sidebar.read_view_options()
+        assert options.split_enabled is True
+        assert options.split_angle_degrees == pytest.approx(90.0)
+    finally:
+        sidebar.deleteLater()
+        app.processEvents()

--- a/tests/test_vessel_drafter_three_d_sidebar.py
+++ b/tests/test_vessel_drafter_three_d_sidebar.py
@@ -1,6 +1,7 @@
 """Tests for the 3D-preview sidebar widget extracted from the window module."""
 
 import os
+from typing import cast
 
 import pytest
 from PyQt6.QtWidgets import QApplication
@@ -13,7 +14,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 
 def _ensure_app() -> QApplication:
-    return QApplication.instance() or QApplication([])
+    return cast(QApplication, QApplication.instance() or QApplication([]))
 
 
 def test_sidebar_exposes_expected_layer_checkboxes() -> None:


### PR DESCRIPTION
## Summary

Partially addresses issue #27 (second half) by splitting the 607-LOC `gui/vessel_drafter_window.py` module along three cohesive seams.

- **`gui/vessel_drafter_preview_panel.py`** (66 LOC) — reusable `PreviewPanel` widget wrapping a `ZoomableGraphicsView` with a titled zoom-control header row. Used for both 2D previews.
- **`gui/vessel_drafter_three_d_sidebar.py`** (118 LOC) — `VesselThreeDSidebar` widget that owns the layer-visibility checkboxes, section-cut controls, reset-view button, and material summary table that sit alongside the 3D canvas. Exposes `visible_layer_labels()` and `read_view_options()` so the window no longer reaches into those controls directly.
- **`gui/vessel_drafter_port_prompts.py`** (58 LOC) — `prompt_add_side_port` / `prompt_add_lid_port` factories that run the port-add `PortValueDialog` and return typed `VesselSidePort` / `VesselLidPort` instances, replacing 39 LOC of inline dialog-construction code.

The main window composes these pieces and keeps backward-compat attribute aliases (`layer_visibility_checkboxes`, `section_cut_checkbox`, `section_cut_angle_spin`, `material_summary_table`) pointing at the sidebar's widgets so the existing test suite and any external callers continue to work. Shared UI state (`_suppress_preview_updates`, `_three_d_preview_dirty`) remains on the window; extracted pieces never reach back into private window attributes.

**LOC**: window 607 -> 489. All extracted modules stay well under the 300-LOC target.

Follows the same style as PR #55 (model-layer split) and the earlier PR #51 / #53 refactors.

## Test plan

- [x] `ruff check src/ tests/` — passes
- [x] `ruff format --check` on touched files — clean
- [x] Import smoke: `from programmatic_drafting.gui.vessel_drafter_window import VesselDrafterWindow` — ok
- [x] Full test suite (`pytest -q`): 130 passed (including 7 pre-existing GUI tests + 10 new tests across the three new modules)
- [x] Existing tests for `_format_status_text` continue to import from the window module unchanged

Note: this repo does not contain a `SPEC.md` / `CHANGELOG.md`, consistent with the earlier refactor PRs under issue #27, so no version bump was required.

Relates to #27.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>