### PR TITLE
refactor(#32): split vessel drafter window helpers

### DIFF
--- a/src/programmatic_drafting/gui/vessel_drafter_window.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_window.py
@@ -7,8 +7,14 @@ from pathlib import Path
 
 from PyQt6.QtWidgets import (
     QApplication,
+    QCheckBox,
+    QDoubleSpinBox,
     QFileDialog,
+    QGraphicsScene,
+    QLabel,
     QMainWindow,
+    QPushButton,
+    QSpinBox,
     QTabWidget,
 )
 
@@ -16,6 +22,8 @@ from programmatic_drafting.analysis.vessel_drafter_metrics import (
     build_material_metrics_report,
 )
 from programmatic_drafting.exporters.step_export import export_vessel_drafter_step
+from programmatic_drafting.gui.material_summary_table import MaterialSummaryTable
+from programmatic_drafting.gui.vessel_drafter_port_panel import PortTableSection
 from programmatic_drafting.gui.vessel_drafter_port_prompts import (
     prompt_add_lid_port,
     prompt_add_side_port,
@@ -24,11 +32,16 @@ from programmatic_drafting.gui.vessel_drafter_rendering import (
     render_cross_section,
     render_plan,
 )
+from programmatic_drafting.gui.vessel_drafter_three_d_canvas import (
+    VesselDrafterThreeDCanvas,
+)
+from programmatic_drafting.gui.vessel_drafter_three_d_sidebar import (
+    VesselThreeDSidebar,
+)
 from programmatic_drafting.gui.vessel_drafter_window_controls import (
     build_dimension_controls,
     build_electrode_controls,
     build_port_panels,
-    build_preview_tabs,
     build_preview_widgets,
     build_ui,
     dimension_controls,
@@ -42,6 +55,7 @@ from programmatic_drafting.gui.vessel_drafter_window_layout_io import (
 from programmatic_drafting.gui.vessel_drafter_window_status import (
     format_status_text as _format_status_text,
 )
+from programmatic_drafting.gui.zoomable_graphics_view import ZoomableGraphicsView
 from programmatic_drafting.models.vessel_drafter import (
     DEFAULT_VESSEL_DRAFTER_LAYOUT,
     VesselDrafterLayout,
@@ -56,16 +70,45 @@ from programmatic_drafting.preview.vessel_drafter_scene import build_vessel_3d_s
 
 
 class VesselDrafterWindow(QMainWindow):
+    inner_diameter_spin: QDoubleSpinBox
+    glass_depth_spin: QDoubleSpinBox
+    plenum_height_spin: QDoubleSpinBox
+    head_depth_spin: QDoubleSpinBox
+    hot_face_spin: QDoubleSpinBox
+    ifb_spin: QDoubleSpinBox
+    duraboard_spin: QDoubleSpinBox
+    steel_spin: QDoubleSpinBox
+    electrode_count_spin: QSpinBox
+    electrode_diameter_spin: QDoubleSpinBox
+    electrode_insertion_spin: QDoubleSpinBox
+    electrode_extension_spin: QDoubleSpinBox
+    side_port_panel: PortTableSection
+    lid_port_panel: PortTableSection
+    cross_section_scene: QGraphicsScene
+    cross_section_view: ZoomableGraphicsView
+    plan_scene: QGraphicsScene
+    plan_view: ZoomableGraphicsView
+    preview_tabs: QTabWidget
+    three_d_canvas: VesselDrafterThreeDCanvas
+    three_d_sidebar: VesselThreeDSidebar
+    layer_visibility_checkboxes: dict[str, QCheckBox]
+    section_cut_checkbox: QCheckBox
+    section_cut_angle_spin: QDoubleSpinBox
+    material_summary_table: MaterialSummaryTable
+    status_label: QLabel
+    refresh_button: QPushButton
+    export_button: QPushButton
+
     def __init__(self) -> None:
         super().__init__()
         self._configure_window()
         self._suppress_preview_updates = False
         self._three_d_preview_dirty = True
-        self._build_dimension_controls()
-        self._build_electrode_controls()
-        self._build_port_panels()
-        self._build_preview_widgets()
-        self._build_ui()
+        build_dimension_controls(self)
+        build_electrode_controls(self)
+        build_port_panels(self)
+        build_preview_widgets(self)
+        build_ui(self)
         self._connect_signals()
         self.write_layout(DEFAULT_VESSEL_DRAFTER_LAYOUT)
         self.update_preview()
@@ -74,21 +117,6 @@ class VesselDrafterWindow(QMainWindow):
         """Apply static top-level window settings."""
         self.setWindowTitle("Vessel Drafter")
         self.resize(1400, 880)
-
-    def _build_dimension_controls(self) -> None:
-        build_dimension_controls(self)
-
-    def _build_electrode_controls(self) -> None:
-        build_electrode_controls(self)
-
-    def _build_port_panels(self) -> None:
-        build_port_panels(self)
-
-    def _build_preview_widgets(self) -> None:
-        build_preview_widgets(self)
-
-    def _build_ui(self) -> None:
-        build_ui(self)
 
     def _connect_signals(self) -> None:
         self._connect_dimension_signals()
@@ -221,9 +249,6 @@ class VesselDrafterWindow(QMainWindow):
     def _remove_selected_lid_ports(self) -> None:
         self.lid_port_panel.remove_selected_rows()
         self.update_preview()
-
-    def _build_preview_tabs(self) -> QTabWidget:
-        return build_preview_tabs(self)
 
     def _update_three_d_preview(self, layout: VesselDrafterLayout) -> None:
         view_options = self.three_d_sidebar.read_view_options()

--- a/src/programmatic_drafting/gui/vessel_drafter_window.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_window.py
@@ -8,44 +8,40 @@ from pathlib import Path
 from PyQt6.QtWidgets import (
     QApplication,
     QFileDialog,
-    QFormLayout,
-    QGraphicsScene,
-    QHBoxLayout,
-    QLabel,
     QMainWindow,
-    QPushButton,
-    QScrollArea,
-    QSpinBox,
     QTabWidget,
-    QVBoxLayout,
-    QWidget,
 )
 
 from programmatic_drafting.analysis.vessel_drafter_metrics import (
-    MaterialMetricsReport,
     build_material_metrics_report,
 )
 from programmatic_drafting.exporters.step_export import export_vessel_drafter_step
-from programmatic_drafting.gui.vessel_drafter_port_panel import (
-    PortTableSection,
-    make_double_spin,
-)
 from programmatic_drafting.gui.vessel_drafter_port_prompts import (
     prompt_add_lid_port,
     prompt_add_side_port,
 )
-from programmatic_drafting.gui.vessel_drafter_preview_panel import PreviewPanel
 from programmatic_drafting.gui.vessel_drafter_rendering import (
     render_cross_section,
     render_plan,
 )
-from programmatic_drafting.gui.vessel_drafter_three_d_canvas import (
-    VesselDrafterThreeDCanvas,
+from programmatic_drafting.gui.vessel_drafter_window_controls import (
+    build_dimension_controls,
+    build_electrode_controls,
+    build_port_panels,
+    build_preview_tabs,
+    build_preview_widgets,
+    build_ui,
+    dimension_controls,
 )
-from programmatic_drafting.gui.vessel_drafter_three_d_sidebar import (
-    VesselThreeDSidebar,
+from programmatic_drafting.gui.vessel_drafter_window_layout_io import (
+    add_lid_port_to_controls,
+    add_side_port_to_controls,
+    read_layout_from_controls,
+    write_layout_to_controls,
 )
-from programmatic_drafting.gui.zoomable_graphics_view import ZoomableGraphicsView
+from programmatic_drafting.gui.vessel_drafter_window_status import (
+    format_status_text as _format_status_text,
+)
 from programmatic_drafting.models.vessel_drafter import (
     DEFAULT_VESSEL_DRAFTER_LAYOUT,
     VesselDrafterLayout,
@@ -80,113 +76,19 @@ class VesselDrafterWindow(QMainWindow):
         self.resize(1400, 880)
 
     def _build_dimension_controls(self) -> None:
-        """Create vessel dimension controls."""
-        self.inner_diameter_spin = make_double_spin(50.0, 1.0, 500.0)
-        self.glass_depth_spin = make_double_spin(14.0, 1.0, 250.0)
-        self.plenum_height_spin = make_double_spin(14.0, 1.0, 250.0)
-        self.head_depth_spin = make_double_spin(12.5, 1.0, 250.0)
-        self.hot_face_spin = make_double_spin(6.0, 0.1, 50.0)
-        self.ifb_spin = make_double_spin(4.5, 0.1, 50.0)
-        self.duraboard_spin = make_double_spin(1.0, 0.1, 20.0)
-        self.steel_spin = make_double_spin(0.5, 0.1, 10.0)
+        build_dimension_controls(self)
 
     def _build_electrode_controls(self) -> None:
-        """Create electrode parameter controls."""
-        self.electrode_count_spin = QSpinBox()
-        self.electrode_count_spin.setRange(1, 12)
-        self.electrode_count_spin.setValue(3)
-        self.electrode_diameter_spin = make_double_spin(2.0, 0.1, 20.0)
-        self.electrode_insertion_spin = make_double_spin(14.0, 0.1, 100.0)
-        self.electrode_extension_spin = make_double_spin(36.0, 0.1, 150.0)
+        build_electrode_controls(self)
 
     def _build_port_panels(self) -> None:
-        """Create editable side and lid port panels."""
-        self.side_port_panel = PortTableSection(
-            "Side Ports",
-            ("Clock Angle", "Diameter", "Height Above Glass"),
-        )
-        self.lid_port_panel = PortTableSection(
-            "Lid Ports",
-            ("Clock Angle", "Diameter", "Distance From Center"),
-        )
+        build_port_panels(self)
 
     def _build_preview_widgets(self) -> None:
-        """Create preview scenes, views, canvas, and sidebar widgets."""
-        self.cross_section_scene = QGraphicsScene(self)
-        self.cross_section_view = ZoomableGraphicsView(self)
-        self.cross_section_view.setScene(self.cross_section_scene)
-        self.plan_scene = QGraphicsScene(self)
-        self.plan_view = ZoomableGraphicsView(self)
-        self.plan_view.setScene(self.plan_scene)
-        self.preview_tabs = QTabWidget(self)
-        self.three_d_canvas = VesselDrafterThreeDCanvas()
-        self.three_d_sidebar = VesselThreeDSidebar()
-        # Expose sidebar sub-widgets for backward compatibility with callers
-        # and tests that reach them through the window.
-        self.layer_visibility_checkboxes = (
-            self.three_d_sidebar.layer_visibility_checkboxes
-        )
-        self.section_cut_checkbox = self.three_d_sidebar.section_cut_checkbox
-        self.section_cut_angle_spin = self.three_d_sidebar.section_cut_angle_spin
-        self.material_summary_table = self.three_d_sidebar.material_summary_table
-        self.status_label = QLabel()
-        self.status_label.setWordWrap(True)
+        build_preview_widgets(self)
 
     def _build_ui(self) -> None:
-        root = QWidget()
-        self.setCentralWidget(root)
-
-        controls_scroll = self._build_controls_scroll_area()
-        preview_layout = QVBoxLayout()
-        preview_layout.addWidget(self._build_preview_tabs(), 1)
-
-        main_layout = QHBoxLayout(root)
-        main_layout.addWidget(controls_scroll, 0)
-        main_layout.addLayout(preview_layout, 1)
-
-    def _build_controls_form(self) -> QFormLayout:
-        """Build the static vessel/electrode controls form."""
-        controls_form = QFormLayout()
-        controls_form.addRow("Inner diameter (in)", self.inner_diameter_spin)
-        controls_form.addRow("Glass depth (in)", self.glass_depth_spin)
-        controls_form.addRow("Plenum height (in)", self.plenum_height_spin)
-        controls_form.addRow("Head depth (in)", self.head_depth_spin)
-        controls_form.addRow("Hot face (in)", self.hot_face_spin)
-        controls_form.addRow("IFB (in)", self.ifb_spin)
-        controls_form.addRow("Duraboard (in)", self.duraboard_spin)
-        controls_form.addRow("Steel (in)", self.steel_spin)
-        controls_form.addRow("Electrode count", self.electrode_count_spin)
-        controls_form.addRow("Electrode diameter (in)", self.electrode_diameter_spin)
-        controls_form.addRow("Electrode insertion (in)", self.electrode_insertion_spin)
-        controls_form.addRow("Electrode extension (in)", self.electrode_extension_spin)
-        return controls_form
-
-    def _build_action_buttons(self) -> tuple[QPushButton, QPushButton]:
-        """Create command buttons and wire their click handlers."""
-        self.refresh_button = QPushButton("Refresh Preview")
-        self.refresh_button.clicked.connect(self.update_preview)
-        self.export_button = QPushButton("Export STEP")
-        self.export_button.clicked.connect(self.export_step_dialog)
-        return self.refresh_button, self.export_button
-
-    def _build_controls_scroll_area(self) -> QScrollArea:
-        """Build the scrollable left-side controls column."""
-        refresh_button, export_button = self._build_action_buttons()
-        controls_root = QWidget()
-        controls_layout = QVBoxLayout(controls_root)
-        controls_layout.addLayout(self._build_controls_form())
-        controls_layout.addWidget(self.side_port_panel)
-        controls_layout.addWidget(self.lid_port_panel)
-        controls_layout.addWidget(refresh_button)
-        controls_layout.addWidget(export_button)
-        controls_layout.addWidget(self.status_label)
-        controls_layout.addStretch(1)
-
-        controls_scroll = QScrollArea()
-        controls_scroll.setWidgetResizable(True)
-        controls_scroll.setWidget(controls_root)
-        controls_scroll.setMinimumWidth(340)
-        return controls_scroll
+        build_ui(self)
 
     def _connect_signals(self) -> None:
         self._connect_dimension_signals()
@@ -194,21 +96,7 @@ class VesselDrafterWindow(QMainWindow):
         self._connect_preview_signals()
 
     def _dimension_controls(self) -> tuple:
-        """Return controls whose value changes refresh the 2D previews."""
-        return (
-            self.inner_diameter_spin,
-            self.glass_depth_spin,
-            self.plenum_height_spin,
-            self.head_depth_spin,
-            self.hot_face_spin,
-            self.ifb_spin,
-            self.duraboard_spin,
-            self.steel_spin,
-            self.electrode_count_spin,
-            self.electrode_diameter_spin,
-            self.electrode_insertion_spin,
-            self.electrode_extension_spin,
-        )
+        return dimension_controls(self)
 
     def _connect_dimension_signals(self) -> None:
         """Connect scalar dimension/electrode controls to preview refresh."""
@@ -242,96 +130,18 @@ class VesselDrafterWindow(QMainWindow):
         )
 
     def write_layout(self, layout: VesselDrafterLayout) -> None:
-        self._suppress_preview_updates = True
-        self.inner_diameter_spin.setValue(layout.inner_diameter_in)
-        self.glass_depth_spin.setValue(layout.glass_depth_in)
-        self.plenum_height_spin.setValue(layout.plenum_height_in)
-        self.head_depth_spin.setValue(layout.head_depth_in)
-        self.hot_face_spin.setValue(layout.hot_face_thickness_in)
-        self.ifb_spin.setValue(layout.ifb_thickness_in)
-        self.duraboard_spin.setValue(layout.duraboard_thickness_in)
-        self.steel_spin.setValue(layout.steel_thickness_in)
-        self.electrode_count_spin.setValue(layout.electrode_count)
-        self.electrode_diameter_spin.setValue(layout.electrode_diameter_in)
-        self.electrode_insertion_spin.setValue(
-            layout.electrode_insertion_into_inner_circle_in
-        )
-        self.electrode_extension_spin.setValue(
-            layout.electrode_extension_past_inner_circle_in
-        )
-        self.side_port_panel.set_rows(
-            tuple(
-                (
-                    port.normalized_clock_angle_degrees,
-                    port.diameter_in,
-                    port.height_above_glass_surface_in,
-                )
-                for port in layout.side_ports
-            )
-        )
-        self.lid_port_panel.set_rows(
-            tuple(
-                (
-                    port.normalized_clock_angle_degrees,
-                    port.diameter_in,
-                    port.radial_distance_from_center_in,
-                )
-                for port in layout.lid_ports
-            )
-        )
-        self._suppress_preview_updates = False
+        write_layout_to_controls(self, layout)
 
     def add_side_port(self, port: VesselSidePort) -> None:
-        self.side_port_panel.append_row(
-            (
-                port.normalized_clock_angle_degrees,
-                port.diameter_in,
-                port.height_above_glass_surface_in,
-            )
-        )
+        add_side_port_to_controls(self, port)
         self.update_preview()
 
     def add_lid_port(self, port: VesselLidPort) -> None:
-        self.lid_port_panel.append_row(
-            (
-                port.normalized_clock_angle_degrees,
-                port.diameter_in,
-                port.radial_distance_from_center_in,
-            )
-        )
+        add_lid_port_to_controls(self, port)
         self.update_preview()
 
     def read_layout(self) -> VesselDrafterLayout:
-        return VesselDrafterLayout(
-            inner_diameter_in=self.inner_diameter_spin.value(),
-            glass_depth_in=self.glass_depth_spin.value(),
-            plenum_height_in=self.plenum_height_spin.value(),
-            head_depth_in=self.head_depth_spin.value(),
-            hot_face_thickness_in=self.hot_face_spin.value(),
-            ifb_thickness_in=self.ifb_spin.value(),
-            duraboard_thickness_in=self.duraboard_spin.value(),
-            steel_thickness_in=self.steel_spin.value(),
-            electrode_count=self.electrode_count_spin.value(),
-            electrode_diameter_in=self.electrode_diameter_spin.value(),
-            electrode_insertion_into_inner_circle_in=self.electrode_insertion_spin.value(),
-            electrode_extension_past_inner_circle_in=self.electrode_extension_spin.value(),
-            side_ports=tuple(
-                VesselSidePort(
-                    clock_angle_degrees=angle,
-                    diameter_in=diameter,
-                    height_above_glass_surface_in=height,
-                )
-                for angle, diameter, height in self.side_port_panel.rows()
-            ),
-            lid_ports=tuple(
-                VesselLidPort(
-                    clock_angle_degrees=angle,
-                    diameter_in=diameter,
-                    radial_distance_from_center_in=radius,
-                )
-                for angle, diameter, radius in self.lid_port_panel.rows()
-            ),
-        )
+        return read_layout_from_controls(self)
 
     def update_preview(self) -> None:
         if self._suppress_preview_updates:
@@ -413,25 +223,7 @@ class VesselDrafterWindow(QMainWindow):
         self.update_preview()
 
     def _build_preview_tabs(self) -> QTabWidget:
-        previews_tab = QWidget()
-        previews_layout = QVBoxLayout(previews_tab)
-        previews_layout.addWidget(
-            PreviewPanel("Cross-Section Preview", self.cross_section_view),
-            1,
-        )
-        previews_layout.addWidget(
-            PreviewPanel("Top View Preview", self.plan_view),
-            1,
-        )
-
-        three_d_tab = QWidget()
-        three_d_layout = QHBoxLayout(three_d_tab)
-        three_d_layout.addWidget(self.three_d_canvas, 1)
-        three_d_layout.addWidget(self.three_d_sidebar, 0)
-
-        self.preview_tabs.addTab(previews_tab, "2D Previews")
-        self.preview_tabs.addTab(three_d_tab, "3D Preview")
-        return self.preview_tabs
+        return build_preview_tabs(self)
 
     def _update_three_d_preview(self, layout: VesselDrafterLayout) -> None:
         view_options = self.three_d_sidebar.read_view_options()
@@ -472,18 +264,3 @@ def launch() -> int:
     window = VesselDrafterWindow()
     window.show()
     return app.exec()
-
-
-def _format_status_text(
-    layout: VesselDrafterLayout,
-    metrics: MaterialMetricsReport,
-) -> str:
-    """Build the compact status summary shown after preview refresh."""
-    return (
-        f"Outer diameter: {layout.outer_diameter_in:.2f} in | "
-        f"Full height: {layout.full_height_in:.2f} in | "
-        f"Ports: {len(layout.side_ports)} side, {len(layout.lid_ports)} lid | "
-        f"Refractory: {metrics.refractory_total_volume_ft3:.2f} ft^3, "
-        f"{metrics.refractory_total_surface_area_ft2:.2f} ft^2, "
-        f"{metrics.refractory_total_mass_lb:.1f} lb"
-    )

--- a/src/programmatic_drafting/gui/vessel_drafter_window_controls.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_window_controls.py
@@ -1,0 +1,188 @@
+"""Widget construction helpers for the vessel drafter main window."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from PyQt6.QtWidgets import (
+    QFormLayout,
+    QGraphicsScene,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QSpinBox,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from programmatic_drafting.gui.vessel_drafter_port_panel import (
+    PortTableSection,
+    make_double_spin,
+)
+from programmatic_drafting.gui.vessel_drafter_preview_panel import PreviewPanel
+from programmatic_drafting.gui.vessel_drafter_three_d_canvas import (
+    VesselDrafterThreeDCanvas,
+)
+from programmatic_drafting.gui.vessel_drafter_three_d_sidebar import (
+    VesselThreeDSidebar,
+)
+from programmatic_drafting.gui.zoomable_graphics_view import ZoomableGraphicsView
+
+
+def build_dimension_controls(window: Any) -> None:
+    """Create vessel dimension controls on ``window``."""
+    window.inner_diameter_spin = make_double_spin(50.0, 1.0, 500.0)
+    window.glass_depth_spin = make_double_spin(14.0, 1.0, 250.0)
+    window.plenum_height_spin = make_double_spin(14.0, 1.0, 250.0)
+    window.head_depth_spin = make_double_spin(12.5, 1.0, 250.0)
+    window.hot_face_spin = make_double_spin(6.0, 0.1, 50.0)
+    window.ifb_spin = make_double_spin(4.5, 0.1, 50.0)
+    window.duraboard_spin = make_double_spin(1.0, 0.1, 20.0)
+    window.steel_spin = make_double_spin(0.5, 0.1, 10.0)
+
+
+def build_electrode_controls(window: Any) -> None:
+    """Create electrode parameter controls on ``window``."""
+    window.electrode_count_spin = QSpinBox()
+    window.electrode_count_spin.setRange(1, 12)
+    window.electrode_count_spin.setValue(3)
+    window.electrode_diameter_spin = make_double_spin(2.0, 0.1, 20.0)
+    window.electrode_insertion_spin = make_double_spin(14.0, 0.1, 100.0)
+    window.electrode_extension_spin = make_double_spin(36.0, 0.1, 150.0)
+
+
+def build_port_panels(window: Any) -> None:
+    """Create editable side and lid port panels on ``window``."""
+    window.side_port_panel = PortTableSection(
+        "Side Ports",
+        ("Clock Angle", "Diameter", "Height Above Glass"),
+    )
+    window.lid_port_panel = PortTableSection(
+        "Lid Ports",
+        ("Clock Angle", "Diameter", "Distance From Center"),
+    )
+
+
+def build_preview_widgets(window: Any) -> None:
+    """Create preview scenes, views, canvas, and sidebar widgets."""
+    window.cross_section_scene = QGraphicsScene(window)
+    window.cross_section_view = ZoomableGraphicsView(window)
+    window.cross_section_view.setScene(window.cross_section_scene)
+    window.plan_scene = QGraphicsScene(window)
+    window.plan_view = ZoomableGraphicsView(window)
+    window.plan_view.setScene(window.plan_scene)
+    window.preview_tabs = QTabWidget(window)
+    window.three_d_canvas = VesselDrafterThreeDCanvas()
+    window.three_d_sidebar = VesselThreeDSidebar()
+    window.layer_visibility_checkboxes = (
+        window.three_d_sidebar.layer_visibility_checkboxes
+    )
+    window.section_cut_checkbox = window.three_d_sidebar.section_cut_checkbox
+    window.section_cut_angle_spin = window.three_d_sidebar.section_cut_angle_spin
+    window.material_summary_table = window.three_d_sidebar.material_summary_table
+    window.status_label = QLabel()
+    window.status_label.setWordWrap(True)
+
+
+def build_ui(window: Any) -> None:
+    """Build the main two-column window layout."""
+    root = QWidget()
+    window.setCentralWidget(root)
+
+    controls_scroll = build_controls_scroll_area(window)
+    preview_layout = QVBoxLayout()
+    preview_layout.addWidget(build_preview_tabs(window), 1)
+
+    main_layout = QHBoxLayout(root)
+    main_layout.addWidget(controls_scroll, 0)
+    main_layout.addLayout(preview_layout, 1)
+
+
+def build_controls_form(window: Any) -> QFormLayout:
+    """Build the static vessel/electrode controls form."""
+    controls_form = QFormLayout()
+    controls_form.addRow("Inner diameter (in)", window.inner_diameter_spin)
+    controls_form.addRow("Glass depth (in)", window.glass_depth_spin)
+    controls_form.addRow("Plenum height (in)", window.plenum_height_spin)
+    controls_form.addRow("Head depth (in)", window.head_depth_spin)
+    controls_form.addRow("Hot face (in)", window.hot_face_spin)
+    controls_form.addRow("IFB (in)", window.ifb_spin)
+    controls_form.addRow("Duraboard (in)", window.duraboard_spin)
+    controls_form.addRow("Steel (in)", window.steel_spin)
+    controls_form.addRow("Electrode count", window.electrode_count_spin)
+    controls_form.addRow("Electrode diameter (in)", window.electrode_diameter_spin)
+    controls_form.addRow("Electrode insertion (in)", window.electrode_insertion_spin)
+    controls_form.addRow("Electrode extension (in)", window.electrode_extension_spin)
+    return controls_form
+
+
+def build_action_buttons(window: Any) -> tuple[QPushButton, QPushButton]:
+    """Create command buttons and wire their click handlers."""
+    window.refresh_button = QPushButton("Refresh Preview")
+    window.refresh_button.clicked.connect(window.update_preview)
+    window.export_button = QPushButton("Export STEP")
+    window.export_button.clicked.connect(window.export_step_dialog)
+    return window.refresh_button, window.export_button
+
+
+def build_controls_scroll_area(window: Any) -> QScrollArea:
+    """Build the scrollable left-side controls column."""
+    refresh_button, export_button = build_action_buttons(window)
+    controls_root = QWidget()
+    controls_layout = QVBoxLayout(controls_root)
+    controls_layout.addLayout(build_controls_form(window))
+    controls_layout.addWidget(window.side_port_panel)
+    controls_layout.addWidget(window.lid_port_panel)
+    controls_layout.addWidget(refresh_button)
+    controls_layout.addWidget(export_button)
+    controls_layout.addWidget(window.status_label)
+    controls_layout.addStretch(1)
+
+    controls_scroll = QScrollArea()
+    controls_scroll.setWidgetResizable(True)
+    controls_scroll.setWidget(controls_root)
+    controls_scroll.setMinimumWidth(340)
+    return controls_scroll
+
+
+def dimension_controls(window: Any) -> tuple[Any, ...]:
+    """Return controls whose value changes refresh the 2D previews."""
+    return (
+        window.inner_diameter_spin,
+        window.glass_depth_spin,
+        window.plenum_height_spin,
+        window.head_depth_spin,
+        window.hot_face_spin,
+        window.ifb_spin,
+        window.duraboard_spin,
+        window.steel_spin,
+        window.electrode_count_spin,
+        window.electrode_diameter_spin,
+        window.electrode_insertion_spin,
+        window.electrode_extension_spin,
+    )
+
+
+def build_preview_tabs(window: Any) -> QTabWidget:
+    """Build the tabbed 2D and 3D preview area."""
+    previews_tab = QWidget()
+    previews_layout = QVBoxLayout(previews_tab)
+    previews_layout.addWidget(
+        PreviewPanel("Cross-Section Preview", window.cross_section_view),
+        1,
+    )
+    previews_layout.addWidget(
+        PreviewPanel("Top View Preview", window.plan_view),
+        1,
+    )
+
+    three_d_tab = QWidget()
+    three_d_layout = QHBoxLayout(three_d_tab)
+    three_d_layout.addWidget(window.three_d_canvas, 1)
+    three_d_layout.addWidget(window.three_d_sidebar, 0)
+
+    window.preview_tabs.addTab(previews_tab, "2D Previews")
+    window.preview_tabs.addTab(three_d_tab, "3D Preview")
+    return window.preview_tabs

--- a/src/programmatic_drafting/gui/vessel_drafter_window_layout_io.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_window_layout_io.py
@@ -1,0 +1,121 @@
+"""Layout read/write helpers for the vessel drafter main window."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from programmatic_drafting.models.vessel_drafter import (
+    VesselDrafterLayout,
+    VesselLidPort,
+    VesselSidePort,
+)
+
+PortRow = tuple[float, float, float]
+
+
+def side_port_rows(ports: tuple[VesselSidePort, ...]) -> tuple[PortRow, ...]:
+    """Convert side ports into editable table rows."""
+    return tuple(
+        (
+            port.normalized_clock_angle_degrees,
+            port.diameter_in,
+            port.height_above_glass_surface_in,
+        )
+        for port in ports
+    )
+
+
+def lid_port_rows(ports: tuple[VesselLidPort, ...]) -> tuple[PortRow, ...]:
+    """Convert lid ports into editable table rows."""
+    return tuple(
+        (
+            port.normalized_clock_angle_degrees,
+            port.diameter_in,
+            port.radial_distance_from_center_in,
+        )
+        for port in ports
+    )
+
+
+def side_ports_from_rows(rows: tuple[PortRow, ...]) -> tuple[VesselSidePort, ...]:
+    """Convert side-port table rows into model objects."""
+    return tuple(
+        VesselSidePort(
+            clock_angle_degrees=angle,
+            diameter_in=diameter,
+            height_above_glass_surface_in=height,
+        )
+        for angle, diameter, height in rows
+    )
+
+
+def lid_ports_from_rows(rows: tuple[PortRow, ...]) -> tuple[VesselLidPort, ...]:
+    """Convert lid-port table rows into model objects."""
+    return tuple(
+        VesselLidPort(
+            clock_angle_degrees=angle,
+            diameter_in=diameter,
+            radial_distance_from_center_in=radius,
+        )
+        for angle, diameter, radius in rows
+    )
+
+
+def write_layout_to_controls(window: Any, layout: VesselDrafterLayout) -> None:
+    """Write a layout into window controls without triggering preview refreshes."""
+    window._suppress_preview_updates = True
+    try:
+        _write_scalar_controls(window, layout)
+        window.side_port_panel.set_rows(side_port_rows(layout.side_ports))
+        window.lid_port_panel.set_rows(lid_port_rows(layout.lid_ports))
+    finally:
+        window._suppress_preview_updates = False
+
+
+def read_layout_from_controls(window: Any) -> VesselDrafterLayout:
+    """Read the current window controls into a validated layout."""
+    return VesselDrafterLayout(
+        inner_diameter_in=window.inner_diameter_spin.value(),
+        glass_depth_in=window.glass_depth_spin.value(),
+        plenum_height_in=window.plenum_height_spin.value(),
+        head_depth_in=window.head_depth_spin.value(),
+        hot_face_thickness_in=window.hot_face_spin.value(),
+        ifb_thickness_in=window.ifb_spin.value(),
+        duraboard_thickness_in=window.duraboard_spin.value(),
+        steel_thickness_in=window.steel_spin.value(),
+        electrode_count=window.electrode_count_spin.value(),
+        electrode_diameter_in=window.electrode_diameter_spin.value(),
+        electrode_insertion_into_inner_circle_in=window.electrode_insertion_spin.value(),
+        electrode_extension_past_inner_circle_in=window.electrode_extension_spin.value(),
+        side_ports=side_ports_from_rows(window.side_port_panel.rows()),
+        lid_ports=lid_ports_from_rows(window.lid_port_panel.rows()),
+    )
+
+
+def add_side_port_to_controls(window: Any, port: VesselSidePort) -> None:
+    """Append a side port row to the window's editable table."""
+    window.side_port_panel.append_row(side_port_rows((port,))[0])
+
+
+def add_lid_port_to_controls(window: Any, port: VesselLidPort) -> None:
+    """Append a lid port row to the window's editable table."""
+    window.lid_port_panel.append_row(lid_port_rows((port,))[0])
+
+
+def _write_scalar_controls(window: Any, layout: VesselDrafterLayout) -> None:
+    window.inner_diameter_spin.setValue(layout.inner_diameter_in)
+    window.glass_depth_spin.setValue(layout.glass_depth_in)
+    window.plenum_height_spin.setValue(layout.plenum_height_in)
+    window.head_depth_spin.setValue(layout.head_depth_in)
+    window.hot_face_spin.setValue(layout.hot_face_thickness_in)
+    window.ifb_spin.setValue(layout.ifb_thickness_in)
+    window.duraboard_spin.setValue(layout.duraboard_thickness_in)
+    window.steel_spin.setValue(layout.steel_thickness_in)
+    window.electrode_count_spin.setValue(layout.electrode_count)
+    window.electrode_diameter_spin.setValue(layout.electrode_diameter_in)
+    window.electrode_insertion_spin.setValue(
+        layout.electrode_insertion_into_inner_circle_in
+    )
+    window.electrode_extension_spin.setValue(
+        layout.electrode_extension_past_inner_circle_in
+    )

--- a/src/programmatic_drafting/gui/vessel_drafter_window_status.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_window_status.py
@@ -1,0 +1,21 @@
+"""Status text formatting for the vessel drafter main window."""
+
+from __future__ import annotations
+
+from programmatic_drafting.analysis.vessel_drafter_metrics import MaterialMetricsReport
+from programmatic_drafting.models.vessel_drafter import VesselDrafterLayout
+
+
+def format_status_text(
+    layout: VesselDrafterLayout,
+    metrics: MaterialMetricsReport,
+) -> str:
+    """Build the compact status summary shown after preview refresh."""
+    return (
+        f"Outer diameter: {layout.outer_diameter_in:.2f} in | "
+        f"Full height: {layout.full_height_in:.2f} in | "
+        f"Ports: {len(layout.side_ports)} side, {len(layout.lid_ports)} lid | "
+        f"Refractory: {metrics.refractory_total_volume_ft3:.2f} ft^3, "
+        f"{metrics.refractory_total_surface_area_ft2:.2f} ft^2, "
+        f"{metrics.refractory_total_mass_lb:.1f} lb"
+    )

--- a/tests/test_vessel_drafter_gui.py
+++ b/tests/test_vessel_drafter_gui.py
@@ -8,7 +8,20 @@ from programmatic_drafting.gui.vessel_drafter_window import (
     VesselDrafterWindow,
     _format_status_text,
 )
-from programmatic_drafting.models.vessel_drafter import VesselLidPort, VesselSidePort
+from programmatic_drafting.gui.vessel_drafter_window_layout_io import (
+    lid_port_rows,
+    lid_ports_from_rows,
+    read_layout_from_controls,
+    side_port_rows,
+    side_ports_from_rows,
+    write_layout_to_controls,
+)
+from programmatic_drafting.gui.vessel_drafter_window_status import format_status_text
+from programmatic_drafting.models.vessel_drafter import (
+    VesselDrafterLayout,
+    VesselLidPort,
+    VesselSidePort,
+)
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
@@ -183,6 +196,80 @@ def test_format_status_text_summarizes_layout_and_metrics() -> None:
     assert f"Outer diameter: {layout.outer_diameter_in:.2f} in" in status
     assert "Ports: 0 side, 0 lid" in status
     assert "Refractory: 2.00 ft^3, 3.50 ft^2, 456.7 lb" in status
+
+    window.close()
+    app.quit()
+
+
+def test_port_row_helpers_round_trip_port_models() -> None:
+    side_port = VesselSidePort(
+        clock_angle_degrees=420.0,
+        diameter_in=3.0,
+        height_above_glass_surface_in=5.0,
+    )
+    lid_port = VesselLidPort(
+        clock_angle_degrees=-90.0,
+        diameter_in=4.0,
+        radial_distance_from_center_in=9.0,
+    )
+
+    side_rows = side_port_rows((side_port,))
+    lid_rows = lid_port_rows((lid_port,))
+
+    assert side_rows == ((60.0, 3.0, 5.0),)
+    assert lid_rows == ((270.0, 4.0, 9.0),)
+    assert side_ports_from_rows(side_rows)[0].clock_angle_degrees == pytest.approx(60.0)
+    assert lid_ports_from_rows(lid_rows)[0].clock_angle_degrees == pytest.approx(270.0)
+
+
+def test_window_layout_io_helpers_round_trip_controls() -> None:
+    app = QApplication.instance() or QApplication([])
+    window = VesselDrafterWindow()
+    layout = VesselDrafterLayout(
+        inner_diameter_in=64.0,
+        glass_depth_in=15.0,
+        side_ports=(
+            VesselSidePort(
+                clock_angle_degrees=30.0,
+                diameter_in=2.0,
+                height_above_glass_surface_in=3.0,
+            ),
+        ),
+        lid_ports=(
+            VesselLidPort(
+                clock_angle_degrees=120.0,
+                diameter_in=3.0,
+                radial_distance_from_center_in=8.0,
+            ),
+        ),
+    )
+
+    write_layout_to_controls(window, layout)
+    read_back = read_layout_from_controls(window)
+
+    assert window._suppress_preview_updates is False
+    assert read_back.inner_diameter_in == pytest.approx(64.0)
+    assert read_back.glass_depth_in == pytest.approx(15.0)
+    assert read_back.side_ports[0].diameter_in == pytest.approx(2.0)
+    assert read_back.lid_ports[0].radial_distance_from_center_in == pytest.approx(8.0)
+
+    window.close()
+    app.quit()
+
+
+def test_status_module_matches_window_compatibility_alias() -> None:
+    app = QApplication.instance() or QApplication([])
+    window = VesselDrafterWindow()
+    layout = window.read_layout()
+    metrics = MaterialMetricsReport(
+        component_metrics=(),
+        refractory_total_volume_in3=1728.0,
+        refractory_total_volume_ft3=1.0,
+        refractory_total_surface_area_ft2=2.5,
+        refractory_total_mass_lb=345.6,
+    )
+
+    assert _format_status_text(layout, metrics) == format_status_text(layout, metrics)
 
     window.close()
     app.quit()


### PR DESCRIPTION
## Summary

- Split vessel drafter window construction into focused control-building helpers.
- Moved layout read/write table binding into a dedicated helper module.
- Moved status text formatting out of the main window module while preserving the compatibility alias.
- Added direct GUI helper tests for port row conversion, layout control round-tripping, and status formatting.

Closes part of #32 by reducing `vessel_drafter_window.py` from 489 lines to 266 lines, below the tracked 300-line monolith threshold.

## Validation

- `python -m black src tests --check`
- `python -m ruff check src tests`
- `python -m pytest` (133 passed)
