### PR TITLE
refactor: split monolithic scripts and decompose oversized functions

### DIFF
--- a/src/programmatic_drafting/gui/vessel_drafter_rendering.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_rendering.py
@@ -155,7 +155,18 @@ def render_plan(scene: QGraphicsScene, preview: PlanPreview) -> None:
         diameter_px + (PREVIEW_MARGIN * 2.0),
         diameter_px + (PREVIEW_MARGIN * 2.0),
     )
+    _render_plan_bands(scene, preview, center_x, center_y)
+    _render_plan_ports(scene, preview, center_x, center_y)
+    _render_plan_electrodes(scene, preview, center_x, center_y)
 
+
+def _render_plan_bands(
+    scene: QGraphicsScene,
+    preview: PlanPreview,
+    center_x: float,
+    center_y: float,
+) -> None:
+    """Render radial material bands as filled concentric ellipses."""
     for band in reversed(preview.bands):
         radius_px = band.outer_radius_in * PREVIEW_SCALE
         item = scene.addEllipse(
@@ -169,12 +180,27 @@ def render_plan(scene: QGraphicsScene, preview: PlanPreview) -> None:
         if item is not None:
             item.setZValue(1.0)
 
+
+def _render_plan_ports(
+    scene: QGraphicsScene,
+    preview: PlanPreview,
+    center_x: float,
+    center_y: float,
+) -> None:
+    """Render lid ports (circles) and side ports (radial features)."""
     for port in preview.lid_ports:
         _add_plan_circle(scene, center_x, center_y, port, 5.0)
-
     for feature in preview.side_ports:
         _add_radial_feature(scene, center_x, center_y, feature, 6.0)
 
+
+def _render_plan_electrodes(
+    scene: QGraphicsScene,
+    preview: PlanPreview,
+    center_x: float,
+    center_y: float,
+) -> None:
+    """Render electrode placements as radial line features."""
     for placement in preview.electrodes:
         _add_radial_feature(
             scene,

--- a/src/programmatic_drafting/models/vessel_drafter_manifest.py
+++ b/src/programmatic_drafting/models/vessel_drafter_manifest.py
@@ -160,6 +160,6 @@ def _build_drafting_assumptions_manifest() -> dict[str, Any]:
         "axis_convention": "Z up",
         "plenum_only_internal_void": True,
         "dished_heads": (
-            "Offset elliptical head profiles with " "constant-thickness shell layers"
+            "Offset elliptical head profiles with constant-thickness shell layers"
         ),
     }

--- a/tests/test_vessel_drafter_manifest.py
+++ b/tests/test_vessel_drafter_manifest.py
@@ -106,6 +106,6 @@ def test_build_drafting_assumptions_manifest_is_stable() -> None:
         "axis_convention": "Z up",
         "plenum_only_internal_void": True,
         "dished_heads": (
-            "Offset elliptical head profiles with " "constant-thickness shell layers"
+            "Offset elliptical head profiles with constant-thickness shell layers"
         ),
     }

--- a/tests/test_vessel_drafter_rendering.py
+++ b/tests/test_vessel_drafter_rendering.py
@@ -1,17 +1,32 @@
 from __future__ import annotations
 
+from math import pi
+
 from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QApplication, QGraphicsScene
 
 from programmatic_drafting.gui.vessel_drafter_rendering import (
     PREVIEW_MARGIN,
     PREVIEW_SCALE,
     _build_projected_side_port_item,
     _projected_side_port_center,
+    _render_plan_bands,
+    _render_plan_electrodes,
+    _render_plan_ports,
+)
+from programmatic_drafting.models.vessel_drafter_types import (
+    RadialBand,
+    VesselElectrodePlacement,
 )
 from programmatic_drafting.preview.vessel_drafter_preview import (
     CrossSectionPreview,
+    PlanCircularFeature,
+    PlanPreview,
+    PlanRadialFeature,
     ProjectedSidePort,
 )
+
+_app = QApplication.instance() or QApplication([])
 
 
 def _preview() -> CrossSectionPreview:
@@ -64,3 +79,55 @@ def test_projected_side_port_item_is_dashed_and_unfilled() -> None:
 
     assert item.pen().style() == Qt.PenStyle.DashLine
     assert item.brush().style() == Qt.BrushStyle.NoBrush
+
+
+def _plan_preview(
+    bands: tuple[RadialBand, ...] = (),
+    electrodes: tuple[VesselElectrodePlacement, ...] = (),
+    side_ports: tuple[PlanRadialFeature, ...] = (),
+    lid_ports: tuple[PlanCircularFeature, ...] = (),
+) -> PlanPreview:
+    return PlanPreview(
+        outer_radius_in=12.0,
+        bands=bands,
+        electrodes=electrodes,
+        side_ports=side_ports,
+        lid_ports=lid_ports,
+    )
+
+
+def test_render_plan_bands_adds_one_ellipse_per_band() -> None:
+    bands = (
+        RadialBand("glass_bath", "#AABBCC", 0.0, 10.0),
+        RadialBand("hot_face", "#112233", 10.0, 12.0),
+    )
+    scene = QGraphicsScene()
+    _render_plan_bands(scene, _plan_preview(bands=bands), 120.0, 120.0)
+    assert len(scene.items()) == 2
+
+
+def test_render_plan_ports_adds_items_for_lid_and_side_ports() -> None:
+    lid = PlanCircularFeature("lid_port_1", "#FF0000", 5.0, 0.0, 2.0)
+    side = PlanRadialFeature("side_port_1", "#00FF00", 45.0, pi / 4, 8.0, 12.0, 1.5)
+    scene = QGraphicsScene()
+    _render_plan_ports(
+        scene,
+        _plan_preview(lid_ports=(lid,), side_ports=(side,)),
+        120.0,
+        120.0,
+    )
+    assert len(scene.items()) == 2
+
+
+def test_render_plan_electrodes_adds_one_item_per_electrode() -> None:
+    electrode = VesselElectrodePlacement(
+        index=1,
+        angle_degrees=0.0,
+        angle_radians=0.0,
+        inner_tip_radius_in=2.0,
+        outer_tip_radius_in=10.0,
+        diameter_in=2.0,
+    )
+    scene = QGraphicsScene()
+    _render_plan_electrodes(scene, _plan_preview(electrodes=(electrode,)), 120.0, 120.0)
+    assert len(scene.items()) == 1


### PR DESCRIPTION
Closes #27
Closes #32

## Summary

- All 3 monolithic files from #27 are already ≤ 300 LOC (split in earlier commits merged to main):
  - `vessel_drafter_scene.py`: 78 LOC
  - `vessel_drafter_window.py`: 291 LOC
  - `vessel_drafter.py`: 285 LOC
- Decomposed the last oversized function from #32: `render_plan` (47 LOC → 14 LOC) by extracting `_render_plan_bands`, `_render_plan_ports`, and `_render_plan_electrodes` — every function in `vessel_drafter_rendering.py` is now ≤ 30 LOC
- All other functions from the #32 checklist were already decomposed in prior commits
- No `print()` calls remain in `src/` (already replaced with `logging`)
- Added 3 new pytest tests covering the new plan rendering helpers
- Applied `ruff format` to fix pre-existing implicit string concatenation in `vessel_drafter_manifest.py`

## Test plan

- [ ] `ruff check src tests` passes
- [ ] `black --check src tests` passes
- [ ] New tests `test_render_plan_bands_adds_one_ellipse_per_band`, `test_render_plan_ports_adds_items_for_lid_and_side_ports`, `test_render_plan_electrodes_adds_one_item_per_electrode` pass
- [ ] Full test suite passes on CI (self-hosted runner with PyQt6 + build123d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)