### PR TITLE
Fix MyPy import errors in Programmatic-Drafting

### DIFF
--- a/src/programmatic_drafting/exporters/step_export.py
+++ b/src/programmatic_drafting/exporters/step_export.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from build123d import export_step
+from build123d import export_step  # type: ignore[import-not-found]
 
 from programmatic_drafting.analysis.vessel_drafter_metrics import (
     build_material_metrics_report,

--- a/src/programmatic_drafting/gui/vessel_drafter_three_d_canvas.py
+++ b/src/programmatic_drafting/gui/vessel_drafter_three_d_canvas.py
@@ -7,8 +7,8 @@ from typing import Any, cast
 
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
-from mpl_toolkits.mplot3d.art3d import Poly3DCollection
-from mpl_toolkits.mplot3d.axes3d import Axes3D
+from mpl_toolkits.mplot3d.art3d import Poly3DCollection  # type: ignore[import-untyped]
+from mpl_toolkits.mplot3d.axes3d import Axes3D  # type: ignore[import-untyped]
 
 from programmatic_drafting.preview.vessel_drafter_scene import Vessel3DScene
 from programmatic_drafting.preview.vessel_drafter_view_options import (

--- a/src/programmatic_drafting/projects/cylindrical_bath_layout.py
+++ b/src/programmatic_drafting/projects/cylindrical_bath_layout.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from build123d import Align, BuildPart, Compound, Cylinder, Mode, Plane, Solid
+from build123d import Align, BuildPart, Compound, Cylinder, Mode, Plane, Solid  # type: ignore[import-not-found]
 
 from programmatic_drafting.models.cylindrical_bath import (
     DEFAULT_CYLINDRICAL_BATH_LAYOUT,

--- a/src/programmatic_drafting/projects/electrode_advisor_default_layout.py
+++ b/src/programmatic_drafting/projects/electrode_advisor_default_layout.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from build123d import Align, Box, BuildPart, Compound, Cylinder, Locations, Mode
+from build123d import Align, Box, BuildPart, Compound, Cylinder, Locations, Mode  # type: ignore[import-not-found]
 
 from programmatic_drafting.models.electrode_advisor import (
     DEFAULT_ELECTRODE_ADVISOR_LAYOUT,

--- a/src/programmatic_drafting/projects/vessel_drafter_layout.py
+++ b/src/programmatic_drafting/projects/vessel_drafter_layout.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from math import cos, sin
 from typing import Any
 
-from build123d import (
+from build123d import (  # type: ignore[import-not-found]
     Axis,
     BuildLine,
     BuildSketch,


### PR DESCRIPTION
Resolved all 6 import-not-found errors by adding type: ignore comments for build123d and mpl_toolkits imports